### PR TITLE
Update sample command to convert from MTLX to SLX

### DIFF
--- a/mxslc/mxslc/Decompiler/decompile.py
+++ b/mxslc/mxslc/Decompiler/decompile.py
@@ -23,6 +23,9 @@ def decompile_file(mtlx_path: str | Path, mxsl_path: str | Path = None) -> None:
 
         print(f"{mtlx_filepath.name} decompiled successfully.")
 
+def decompile_string(mtlx_content: str) -> str:    
+    decompiler = Decompiler(mtlx_content)
+    return decompiler.decompile()
 
 class Decompiler:
     def __init__(self, mtlx_filepath: Path):

--- a/tools/mtlx_to_slx.py
+++ b/tools/mtlx_to_slx.py
@@ -1,3 +1,43 @@
-import mxslc
+import sys
+import argparse
+from pathlib import Path
 
-mxslc.decompile_file(r"your\path\to\material.mtlx")
+try:
+    # Import the Decompiler class directly from the module where it's defined
+    from mxslc.Decompiler.decompile import Decompiler
+except ImportError as e:
+    print(f"Error: Could not import Decompiler. Error: {e}")
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert MaterialX files to SLX format.")
+    parser.add_argument(dest='input_file', help="Path to the input MaterialX file (.mtlx)")
+    parser.add_argument("-o", "--output_file", dest="output_file", default="", type=str, help="Path to the output SLX file (.slx)")
+    
+    args = parser.parse_args()
+    input_file = Path(args.input_file)
+    if not input_file.exists():
+        print(f"Input file does not exist: {input_file}")
+        sys.exit(1)
+    
+    decompiler = Decompiler(input_file)
+    
+    # Decompile the MaterialX file
+    try:
+        mxsl_output = decompiler.decompile()
+    except Exception as e:
+        print(f"Error during decompilation: {e}")
+        sys.exit(1)
+    
+    output_file = args.output_file
+    if len(output_file) == 0:
+        print(mxsl_output)
+    else:
+        output_file = Path(output_file)
+        with open(output_file, "w") as f:
+            f.write(mxsl_output)
+        print(f"Output written to: {output_file}")
+    
+if __name__ == "__main__":
+    main()

--- a/tools/mtlx_to_slx.py
+++ b/tools/mtlx_to_slx.py
@@ -3,16 +3,20 @@ import argparse
 from pathlib import Path
 
 try:
-    # Import the Decompiler class directly from the module where it's defined
     from mxslc.Decompiler.decompile import Decompiler
 except ImportError as e:
-    print(f"Error: Could not import Decompiler. Error: {e}")
+    print(f"Error: Could not import decompiler. Error: {e}")
     sys.exit(1)
 
+try:
+    from mxslc.Decompiler.decompile import decompile_string
+except ImportError as e:
+    print(f"Error: Could not import decompile_string function. Error: {e}")
 
-def decompile_string(mtlx_content: str) -> str:    
+
+def decompile_string_local(mtlx_content: str) -> str:    
     """
-    Decompile a MaterialX string content to SLX string.
+    Decompile MaterialX in XML format to SLX string.
     """
     decompiler = Decompiler(mtlx_content)
     return decompiler.decompile()
@@ -21,7 +25,7 @@ def main():
     parser = argparse.ArgumentParser(description="Convert MaterialX files to SLX format.")
     parser.add_argument(dest='input_file', help="Path to the input MaterialX file (.mtlx)")
     parser.add_argument("-o", "--output_file", dest="output_file", default="", type=str, help="Path to the output SLX file (.slx). If not provided, output will be printed to stdout.")
-    
+
     args = parser.parse_args()
     input_file = Path(args.input_file)
     if not input_file.exists():
@@ -33,7 +37,10 @@ def main():
         mtlx_content = f.read()
 
     try:
-        mxsl_output = decompile_string(mtlx_content)
+        if decompile_string:
+            mxsl_output = decompile_string(mtlx_content)
+        else:
+            mxsl_output = decompile_string_local(mtlx_content)
     except Exception as e:
         print(f"Error during decompilation: {e}")
         sys.exit(1)

--- a/tools/mtlx_to_slx.py
+++ b/tools/mtlx_to_slx.py
@@ -10,10 +10,17 @@ except ImportError as e:
     sys.exit(1)
 
 
+def decompile_string(mtlx_content: str) -> str:    
+    """
+    Decompile a MaterialX string content to SLX string.
+    """
+    decompiler = Decompiler(mtlx_content)
+    return decompiler.decompile()
+
 def main():
     parser = argparse.ArgumentParser(description="Convert MaterialX files to SLX format.")
     parser.add_argument(dest='input_file', help="Path to the input MaterialX file (.mtlx)")
-    parser.add_argument("-o", "--output_file", dest="output_file", default="", type=str, help="Path to the output SLX file (.slx)")
+    parser.add_argument("-o", "--output_file", dest="output_file", default="", type=str, help="Path to the output SLX file (.slx). If not provided, output will be printed to stdout.")
     
     args = parser.parse_args()
     input_file = Path(args.input_file)
@@ -21,13 +28,18 @@ def main():
         print(f"Input file does not exist: {input_file}")
         sys.exit(1)
     
-    decompiler = Decompiler(input_file)
-    
-    # Decompile the MaterialX file
+    mtlx_content = ""
+    with open(input_file, 'r') as f:
+        mtlx_content = f.read()
+
     try:
-        mxsl_output = decompiler.decompile()
+        mxsl_output = decompile_string(mtlx_content)
     except Exception as e:
         print(f"Error during decompilation: {e}")
+        sys.exit(1)
+
+    if not mxsl_output:
+        print("No output produced from decompilation.")
         sys.exit(1)
     
     output_file = args.output_file


### PR DESCRIPTION
## Proposal

Set up a full command for the conversion from MTLX to SLX.  

### Changes
- Ad a string -> string decompile API to the Decompiler sub-module which complements the file interface.
  - Note that this is also a desired interface for other tooling which does not wish to read / write to disk.
- Use this for the updated command.

### Notes:
- There is no "version" to check against so for now it checks for the existence of this new method. A version check would make this a bit easier. The alternative is to that this command is tied to the release and hence no check is required.

@jakethorn, I'm just putting this up as a trial change. I have not touched the reverse direction which appears to be inside of main.py. This makes it a bit non-orthogonal. 
