### PR TITLE
Possible install / test setup and instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,53 @@ Currently, MaterialX shaders can be made either using the MaterialX C++ or Pytho
 # Getting Started
 
 ## Installation
-__ShadingLanguageX__ source files are compiled to MaterialX (.mtlx) files using its open source compiler (mxslc). The compiler is written in python and can be downloaded from this repo or PyPI using `pip install mxslc`. It has been tested with Python 3.12 and 3.13. 
+
+### From PyPI
+__ShadingLanguageX__ source files are compiled to MaterialX (.mtlx) files using its open source compiler (mxslc). The compiler is written in python and can be downloaded from PyPI using `pip install mxslc`. It has been tested with Python 3.12 and 3.13.
+
+```bash
+pip install mxslc
+```
+
+### Local Development
+
+For development or to use the latest features:
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/jakethorn/ShadingLanguageX.git
+   cd ShadingLanguageX
+   ```
+
+2. Run the installation script:
+   
+   ```bash
+   source install.sh
+   ```
+
+3. Or install manually:
+   ```bash
+   cd mxslc
+   pip install -r requirements.txt
+   pip install -e .
+   ```
+
+4. Unit tests can be run using:
+   ```bash
+   cd mxslc
+   python -m pytest
+   ```
+
+## Usage
+
+### Python API
+
 ```python
 import mxslc
 mxslc.compile_file("my_shader.mxsl")
 ```
+
+## Executable
 Alternatively, you can download the compiler executable from the most recent release and call it from the command line.
 ```
 > ./mxslc.exe my_shader.mxsl

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+echo "Installing ShadingLanguageX (mxslc)..."
+echo
+
+# Check if Python is installed
+if ! command -v python3 &> /dev/null; then
+    if ! command -v python &> /dev/null; then
+        echo "Error: Python is not installed or not in PATH"
+        echo "Please install Python 3.12 or 3.13 and try again"
+        exit 1
+    else
+        PYTHON_CMD="python"
+    fi
+else
+    PYTHON_CMD="python3"
+fi
+
+# Check Python version
+echo "Checking Python version..."
+$PYTHON_CMD -c "import sys; exit(0 if sys.version_info >= (3, 12) else 1)"
+if [ $? -ne 0 ]; then
+    echo "Error: Python 3.12 or higher required"
+    echo "Current version:"
+    $PYTHON_CMD --version
+    exit 1
+fi
+
+echo "Python version OK"
+echo
+
+# Navigate to script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pushd .
+cd "$SCRIPT_DIR/mxslc"
+
+# Install dependencies
+echo "Installing dependencies..."
+pip install -r requirements.txt
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to install dependencies"
+    popd
+    exit 1
+fi
+
+# Install package in editable mode
+echo "Installing mxslc package..."
+pip install -e .
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to install mxslc package"
+    popd
+    exit 1
+fi
+
+# Test installation
+echo "Testing installation..."
+$PYTHON_CMD -c "import mxslc; print('- mxslc imported successfully')"
+if [ $? -ne 0 ]; then
+    echo "Warning: Installation may not be complete"
+else
+    echo "- Installation verified"
+fi
+
+popd

--- a/mxslc/pyproject.toml
+++ b/mxslc/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mxslc"
+version = "0.5.2-beta"
+requires-python = ">=3.12"
+dependencies = [
+    "MaterialX~=1.39.3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest~=8.3.5",
+]
+[project.scripts]
+mxslc = "mxslc.main:main"
+
+[tool.setuptools]
+packages = ["mxslc"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]


### PR DESCRIPTION
## Proposal

- Add a simple Python package setup file and utility script to allow for simple local development setup.
- Update the README to mention how to do this.

## Implementation
- Add minimal `pyproject.toml` file to use `setuptools`.
- Add `install.sh` utility to perform basic installation
- Add how to manually or using `install.sh` to install. Also mention how to run tests.

@jakethorn : This is a sample setup that I'm using. Up to you if you see this as being generally useful or not. BTW, I noticed there is no `__main__.py` for the package. 