### PR TITLE
Feature/out parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Version 0.5.3-beta (in development)
 ## Added
-* __Inline Keyword ([docs](https://github.com/jakethorn/ShadingLanguageX/blob/main/docs/LanguageSpecification.md#statement-modifiers))__  
+* __Inline Keyword ([docs](https://github.com/jakethorn/ShadingLanguageX/blob/main/docs/LanguageSpecification.md#inline))__  
 The `inline` keyword forces the statements in a function to be created directly in the enclosing
 scope at each point that the function is called instead of compiling into a `NodeDef`+`NodeGraph`.
+
+
+* __Out Parameters ([docs](https://github.com/jakethorn/ShadingLanguageX/blob/main/docs/LanguageSpecification.md#out-parameters))__  
+Including the `out` keyword before a parameter turns it into an out parameter. These parameters can then be set inside the function
+and the value will be accessible when the function is called, similar to a return value.
+
+
+* __Variable Declaration Expressions__  
+To compliment out parameters, variables can now be declared as part of the function call, e.g.: `separate2(float x, float y, texcoord());`
 
 # Version 0.5.2-beta
 ## Added

--- a/docs/PythonAPI.md
+++ b/docs/PythonAPI.md
@@ -19,7 +19,8 @@ def compile_file(mxsl_path: str | Path,
                  main_func: str | None = None,
                  main_args: Sequence[mxslc.Value] | None = None,
                  add_include_dirs: Sequence[Path] | None = None,
-                 add_macros: Sequence[str | mxslc.Macro] | None = None) -> None
+                 add_macros: Sequence[str | mxslc.Macro] | None = None
+                 validate: bool = False) -> None
 ```
 
 ### Example

--- a/docs/SyntaxGrammar.md
+++ b/docs/SyntaxGrammar.md
@@ -6,7 +6,7 @@ statement   → ( attribute* ) ( declaration | assignment | for_loop ) ;
 declaration → var_decl | func_decl;  
 var_decl    → TYPE IDENTIFIER "=" expression ";" ;  
 func_decl   → "inline"? TYPE IDENTIFIER ( "<" TYPE ( "," TYPE )* ">" )? "(" ( parameter ( "," parameter )* )? ")" "{" statement* return "}" ;  
-  parameter → TYPE IDENTIFIER ( "=" expression )? ;  
+  parameter → "out"? TYPE IDENTIFIER ( "=" expression )? ;  
   return    → "return" expression ";" ;  
 assignment  → var_assign | cmp_assign ;  
 var_assign  → variable "=" expression ";" ;  

--- a/mxslc/main.py
+++ b/mxslc/main.py
@@ -24,6 +24,7 @@ def _main(raw_args: list[str] = None):
     parser.add_argument("-a", "--main-args", nargs="+", default=[], help="Arguments to be passed to the main function")
     parser.add_argument("-i", "--include-dirs", nargs="+", default=[], type=Path, help="Additional directories to search when including files")
     parser.add_argument("-d", "--define", dest="macros", nargs="+", action="append", default=[], type=str, help="Additional macro definitions")
+    parser.add_argument("-v", "--validate", action="store_true", help="Validate the output MaterialX file")
     args = parser.parse_args(raw_args)
 
     try:
@@ -33,7 +34,8 @@ def _main(raw_args: list[str] = None):
             main_func=args.main_func,
             main_args=_parse_main_args(args.main_args),
             add_include_dirs=args.include_dirs,
-            add_macros=[Macro(*m) for m in args.macros]
+            add_macros=[Macro(*m) for m in args.macros],
+            validate=args.validate
         )
     except Exception as e:
         print(e)

--- a/mxslc/mxslc/DataType.py
+++ b/mxslc/mxslc/DataType.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import MaterialX as mx
 
-from .CompileError import CompileError
 from .Keyword import Keyword
 from .Token import Token
 
@@ -28,9 +27,6 @@ class DataType:
             self.__data_type = data_type
         else:
             raise TypeError
-        # TODO remove once SLX supports multioutput nodes
-        if self.__data_type == "multioutput":
-            raise CompileError("SLX does not currently support multioutput nodes.")
         assert self.__data_type in Keyword.DATA_TYPES() ^ {Keyword.VOID, Keyword.AUTO}, self.__data_type
 
     def instantiate(self, template_type: DataType | None) -> DataType:

--- a/mxslc/mxslc/Decompiler/decompile.py
+++ b/mxslc/mxslc/Decompiler/decompile.py
@@ -9,7 +9,7 @@ from ..Expressions.LiteralExpression import NullExpression
 from ..Statements import VariableDeclaration, Statement
 from ..Token import IdentifierToken, Token, LiteralToken
 from ..file_utils import handle_input_path, handle_output_path
-from ..mx_wrapper import Document, Node, Input
+from ..mx_wrapper import Document, Node, Input, Output
 
 
 def decompile_file(mtlx_path: str | Path, mxsl_path: str | Path = None) -> None:
@@ -27,6 +27,8 @@ def decompile_file(mtlx_path: str | Path, mxsl_path: str | Path = None) -> None:
 class Decompiler:
     def __init__(self, mtlx_filepath: Path):
         self.__doc = Document(mtlx_filepath)
+        self.__doc.load_standard_library()
+        self.__func_names = {nd.node_string for nd in self.__doc.node_defs}
         self.__nodes: list[Node] = self.__doc.get_nodes()
         self.__decompiled_nodes: list[Node] = []
         self.__mxsl = ""
@@ -42,45 +44,40 @@ class Decompiler:
             self.__decompiled_nodes.append(node)
             input_nodes = [i.connected_node for i in node.inputs if i.connected_node]
             self.__decompile(input_nodes)
-            self.__mxsl += f"{_deexecute(node)}\n"
+            self.__mxsl += f"{self.__deexecute(node)}\n"
 
+    def __deexecute(self, node: Node) -> VariableDeclaration:
+        identifier = IdentifierToken(node.name)
+        expr = self.__node_to_expression(node)
+        return VariableDeclaration(node.data_type, identifier, expr)
 
-def _deexecute(node: Node) -> Statement:
-    identifier = IdentifierToken(node.name)
-    expr = _node_to_expression(node)
-    return VariableDeclaration(node.data_type, identifier, expr)
-
-
-def _node_to_expression(node: Node) -> Expression:
-    if node.source.getType() == "multioutput":
-        raise DecompileError("SLX does not currently support multioutput nodes", node)
-    category = node.category
-    data_type = node.data_type
-    args = _inputs_to_arguments(node.inputs)
-    if category == "constant":
-        return _get_expression(args, 0)
-    if category in ["convert", "combine2", "combine3", "combine4"]:
-        return ConstructorCall(data_type, args)
-    if category == "extract":
-        return IndexingExpression(_get_expression(args, "in"), _get_expression(args, "index"))
-    if category == "switch":
-        values = [a.expression for a in args if "in" in a.name]
-        return SwitchExpression(_get_expression(args, "which"), values)
-    if category in _arithmetic_ops:
-        return BinaryExpression(_get_expression(args, 0), Token(_arithmetic_ops[category]), _get_expression(args, 1))
-    if category in _comparison_ops:
-        expr = BinaryExpression(_get_expression(args, "value1"), Token(_comparison_ops[category]), _get_expression(args, "value2"))
-        if data_type == BOOLEAN and len(args) <= 2:
-            return expr
-        return IfExpression(expr, _get_expression(args, "in1"), _get_expression(args, "in2"))
-    if category in _logic_ops:
-        return BinaryExpression(_get_expression(args, 0), Token(_logic_ops[category]), _get_expression(args, 1))
-    if category in _unary_ops:
-        return UnaryExpression(Token(_unary_ops[category]), _get_expression(args, "in"))
-    if category in _stdlib_functions:
-        return FunctionCall(IdentifierToken(category), None, args)
-    category_token = LiteralToken(category)
-    return NodeConstructor(category_token, data_type, args)
+    def __node_to_expression(self, node: Node) -> Expression:
+        category = node.category
+        args = _inputs_to_arguments(node.inputs)
+        if category == "constant":
+            return _get_expression(args, 0)
+        if category in ["convert", "combine2", "combine3", "combine4"]:
+            return ConstructorCall(node.data_type, args)
+        if category == "extract":
+            return IndexingExpression(_get_expression(args, "in"), _get_expression(args, "index"))
+        if category == "switch":
+            values = [a.expression for a in args if "in" in a.name]
+            return SwitchExpression(_get_expression(args, "which"), values)
+        if category in _arithmetic_ops:
+            return BinaryExpression(_get_expression(args, 0), Token(_arithmetic_ops[category]), _get_expression(args, 1))
+        if category in _comparison_ops:
+            expr = BinaryExpression(_get_expression(args, "value1"), Token(_comparison_ops[category]), _get_expression(args, "value2"))
+            if node.data_type == BOOLEAN and len(args) <= 2:
+                return expr
+            return IfExpression(expr, _get_expression(args, "in1"), _get_expression(args, "in2"))
+        if category in _logic_ops:
+            return BinaryExpression(_get_expression(args, 0), Token(_logic_ops[category]), _get_expression(args, 1))
+        if category in _unary_ops:
+            return UnaryExpression(Token(_unary_ops[category]), _get_expression(args, "in"))
+        if category in self.__func_names:
+            return FunctionCall(IdentifierToken(category), None, args)
+        category_token = LiteralToken(category)
+        return NodeConstructor(category_token, node.data_type, args)
 
 
 def _inputs_to_arguments(inputs: list[Input]) -> list[Argument]:
@@ -125,14 +122,6 @@ def _get_expression(args: list[Argument], index: int | str) -> Expression:
         return NullExpression()
     raise AssertionError
 
-
-def _get_stdlib_functions() -> set[str]:
-    document = Document()
-    document.load_standard_library()
-    return {nd.node_string for nd in document.node_defs}
-
-
-_stdlib_functions = _get_stdlib_functions()
 
 _arithmetic_ops = {
     "add": "+",

--- a/mxslc/mxslc/Expressions/IdentifierExpression.py
+++ b/mxslc/mxslc/Expressions/IdentifierExpression.py
@@ -10,6 +10,10 @@ class IdentifierExpression(Expression):
         super().__init__(identifier)
         self.__identifier = identifier
 
+    @property
+    def identifier(self) -> Token:
+        return self.__identifier
+
     def instantiate_templated_types(self, template_type: DataType) -> Expression:
         return IdentifierExpression(self.__identifier)
 

--- a/mxslc/mxslc/Expressions/VariableDeclarationExpression.py
+++ b/mxslc/mxslc/Expressions/VariableDeclarationExpression.py
@@ -1,0 +1,21 @@
+from . import Expression, IdentifierExpression
+from .. import node_utils, state
+from ..DataType import DataType
+from ..Token import Token
+
+
+class VariableDeclarationExpression(IdentifierExpression):
+    def __init__(self, data_type: Token | DataType, identifier: Token):
+        super().__init__(identifier)
+        self.__data_type = DataType(data_type)
+        self.__identifier = identifier
+
+    def instantiate_templated_types(self, template_type: DataType) -> Expression:
+        return VariableDeclarationExpression(self.__data_type.instantiate(template_type), self.__identifier)
+
+    def _init(self, valid_types: set[DataType]) -> None:
+        node = node_utils.constant(self.__data_type.default())
+        state.add_node(self.__identifier, node)
+
+    def __str__(self) -> str:
+        return f"{self.__data_type} {self.__identifier}"

--- a/mxslc/mxslc/Function.py
+++ b/mxslc/mxslc/Function.py
@@ -214,7 +214,10 @@ class NodeGraphFunction(Function):
 
     @staticmethod
     def from_node_def(node_def: NodeDef) -> Function:
-        return_type = node_def.output.data_type
+        if node_def.output_count == 1:
+            return_type = node_def.output.data_type
+        else:
+            return_type = VOID
         identifier = IdentifierToken(node_def.node_string)
         template_keyword = node_def.name.split("_")[-1]
         if template_keyword in Keyword.DATA_TYPES():
@@ -222,6 +225,10 @@ class NodeGraphFunction(Function):
         else:
             template_type = None
         params = ParameterList()
+        if node_def.output_count > 1:
+            for output in node_def.outputs:
+                param_identifier = IdentifierToken(output.name)
+                params += Parameter(param_identifier, output.data_type, is_out=True)
         for input_ in node_def.inputs:
             param_identifier = IdentifierToken(input_.name)
             params += Parameter(param_identifier, input_.data_type, NullExpression())

--- a/mxslc/mxslc/Function.py
+++ b/mxslc/mxslc/Function.py
@@ -9,7 +9,7 @@ from .Argument import Argument
 from .Attribute import Attribute
 from .CompileError import CompileError
 from .DataType import DataType, VOID
-from .Expressions import Expression
+from .Expressions import Expression, IdentifierExpression
 from .Expressions.LiteralExpression import NullExpression
 from .Keyword import Keyword
 from .Parameter import ParameterList, Parameter
@@ -68,6 +68,14 @@ class Function(ABC):
     def line(self) -> int:
         return self._identifier.line
 
+    @property
+    def _in_params(self) -> ParameterList:
+        return self._params.ins
+
+    @property
+    def _out_params(self) -> ParameterList:
+        return self._params.outs
+
     @abstractmethod
     def initialise(self) -> None:
         ...
@@ -109,11 +117,14 @@ class Function(ABC):
         else:
             return f"{self.return_type} {self.name}({self.parameters})"
 
-    def _initialise_arguments(self, args: list[Argument]) -> dict[str, Node]:
+    def _sort_arguments(self, args: list[Argument]) -> dict[str, Expression]:
         pairs: dict[str, Expression] = {p.name: p.default_value for p in self._params}
         for arg in args:
             pairs[self._params[arg].name] = arg.expression
-        return {name: expr.evaluate() for name, expr in pairs.items()}
+        return pairs
+
+    def _evaluate_arguments(self, args: dict[str, Expression]) -> dict[str, Node]:
+        return {name: expr.evaluate() for name, expr in args.items()}
 
 
 class InlineFunction(Function):
@@ -136,14 +147,18 @@ class InlineFunction(Function):
             raise CompileError("Attributes cannot be defined above an inline function.", self._identifier)
 
     def invoke(self, args: list[Argument]) -> Node:
-        func_args = self._initialise_arguments(args)
+        func_args = self._sort_arguments(args)
+        func_arg_nodes = self._evaluate_arguments(func_args)
         state.enter_inline()
-        for name, node in func_args.items():
+        for name, node in func_arg_nodes.items():
             state.add_node(name, node)
         for stmt in self._body:
             stmt.execute()
+        out_nodes = {p.name: state.get_node(p.name) for p in self._out_params}
         retval = self._return_expr.init_evaluate(self._return_type)
         state.exit_inline()
+        for name, node in out_nodes.items():
+            state.set_node(name, node)
         return retval
 
 
@@ -197,12 +212,6 @@ class NodeGraphFunction(Function):
     def invoke(self, args: list[Argument]) -> Node:
         return self.__call_node_def(args)
 
-    def __str__(self) -> str:
-        if self._template_type:
-            return f"{self.return_type} {self.name}<{self._template_type}>({self.parameters})"
-        else:
-            return f"{self.return_type} {self.name}({self.parameters})"
-
     @staticmethod
     def from_node_def(node_def: NodeDef) -> Function:
         return_type = node_def.output.data_type
@@ -223,26 +232,35 @@ class NodeGraphFunction(Function):
 
     def __create_node_def(self) -> None:
         self.__node_def = get_document().add_node_def(self.fullname, self._return_type, self.name)
-        for param in self._params:
+        for param in self._in_params:
             self.__node_def.add_input(param.name, data_type=param.data_type)
+        for param in self._out_params:
+            self.__node_def.add_output(param.name, data_type=param.data_type)
 
     def __create_node_graph(self) -> None:
         self.__node_graph = get_document().add_node_graph_from_def(self.__node_def)
+        for param in self._out_params:
+            self.__node_graph.add_output(param.name, data_type=param.data_type)
         state.enter_node_graph(self.__node_graph)
+        for param in self._out_params:
+            state.add_node(param.name, node_utils.constant(param.data_type.default()))
         for stmt in self._body:
             stmt.execute()
         retval = self._return_expr.init_evaluate(self._return_type)
         self.__node_graph.add_output("out", retval)
+        for param in self._out_params:
+            self.__node_graph.set_output(param.name, state.get_node(param.name))
         self.__implicit_outs = state.exit_node_graph()
 
     def __call_node_def(self, args: list[Argument]) -> Node:
         assert self.__node_def is not None
-        func_args = self._initialise_arguments(args)
+        func_args = self._sort_arguments(args)
+        func_arg_nodes = self._evaluate_arguments(func_args)
         node = node_utils.create(self.name, self.return_type)
         # add inputs to node
         for nd_input in self.__node_def.inputs:
-            if nd_input.name in func_args:
-                node.add_input(nd_input.name, func_args[nd_input.name])
+            if nd_input.name in func_arg_nodes:
+                node.add_input(nd_input.name, func_arg_nodes[nd_input.name])
             else:
                 node.add_input(nd_input.name, state.get_node(nd_input.name))
         # add outputs to node
@@ -260,13 +278,25 @@ class NodeGraphFunction(Function):
             if len(self.__implicit_outs) == 1:
                 name = list(self.__implicit_outs.keys())[0]
                 state.set_node(name, node)
+            if len(self._out_params) == 1:
+                arg_expr = func_args[self._out_params[0].name]
+                if not isinstance(arg_expr, IdentifierExpression):
+                    raise CompileError(f"Invalid argument being passed to out parameter: {arg_expr}.", arg_expr.token)
+                state.set_node(arg_expr.identifier, node)
             return node
         else:
             for name, ng_output in self.__implicit_outs.items():
                 node_output = node.get_output(ng_output.name)
                 dot_node = node_utils.dot(node_output)
                 state.set_node(name, dot_node)
-            if self.__node_def.output_count == len(self.__implicit_outs):
+            for param in self._out_params:
+                arg_expr = func_args[param.name]
+                if not isinstance(arg_expr, IdentifierExpression):
+                    raise CompileError(f"Invalid argument being passed to out parameter: {arg_expr}.", arg_expr.token)
+                node_output = node.get_output(param.name)
+                dot_node = node_utils.dot(node_output)
+                state.set_node(arg_expr.identifier, dot_node)
+            if self.__node_def.output_count == len(self.__implicit_outs) + len(self._out_params):
                 return node
             else:
                 dot_node = node_utils.dot(node.output)

--- a/mxslc/mxslc/Function.py
+++ b/mxslc/mxslc/Function.py
@@ -158,7 +158,10 @@ class InlineFunction(Function):
         retval = self._return_expr.init_evaluate(self._return_type)
         state.exit_inline()
         for name, node in out_nodes.items():
-            state.set_node(name, node)
+            arg_expr = func_args[name]
+            if not isinstance(arg_expr, IdentifierExpression):
+                raise CompileError(f"Invalid argument being passed to out parameter: {arg_expr}.", arg_expr.token)
+            state.set_node(arg_expr.identifier, node)
         return retval
 
 

--- a/mxslc/mxslc/Parameter.py
+++ b/mxslc/mxslc/Parameter.py
@@ -46,7 +46,10 @@ class Parameter:
             self.default_value.init(self.data_type)
 
     def __str__(self) -> str:
-        output = f"{self.data_type} {self.name}"
+        output = ""
+        if self.is_out:
+            output += "out "
+        output += f"{self.data_type} {self.name}"
         if self.default_value:
             output += f" = {self.default_value}"
         return output

--- a/mxslc/mxslc/Parameter.py
+++ b/mxslc/mxslc/Parameter.py
@@ -11,10 +11,11 @@ class Parameter:
     """
     Represents a parameter to a function or constructor call.
     """
-    def __init__(self, identifier: Token, data_type: Token | DataType, default_value: Expression = None):
+    def __init__(self, identifier: Token, data_type: Token | DataType, default_value: Expression = None, is_out=False):
         self.__identifier = identifier
         self.__data_type = DataType(data_type)
         self.__default_value = default_value
+        self.__is_out = is_out
 
     @property
     def name(self) -> str:
@@ -31,6 +32,14 @@ class Parameter:
     @property
     def default_value(self) -> Expression | None:
         return self.__default_value
+
+    @property
+    def is_in(self) -> bool:
+        return not self.__is_out
+
+    @property
+    def is_out(self) -> bool:
+        return self.__is_out
 
     def init_default_value(self) -> None:
         if self.default_value:
@@ -54,6 +63,14 @@ class ParameterList:
             self.__params: list[Parameter] = params
         else:
             self.__params: list[Parameter] = []
+
+    @property
+    def ins(self) -> ParameterList:
+        return ParameterList([p for p in self if p.is_in])
+
+    @property
+    def outs(self) -> ParameterList:
+        return ParameterList([p for p in self if p.is_out])
 
     def instantiate_templated_parameters(self, template_type: DataType) -> ParameterList:
         return ParameterList([

--- a/mxslc/mxslc/Statements/ExpressionStatement.py
+++ b/mxslc/mxslc/Statements/ExpressionStatement.py
@@ -17,3 +17,6 @@ class ExpressionStatement(Statement):
         self._add_attributes_to_node(node)
         if node.is_null_node:
             node.remove()
+
+    def __str__(self) -> str:
+        return f"{self.__expr};"

--- a/mxslc/mxslc/Statements/ExpressionStatement.py
+++ b/mxslc/mxslc/Statements/ExpressionStatement.py
@@ -15,3 +15,5 @@ class ExpressionStatement(Statement):
     def execute(self) -> None:
         node = self.__expr.init_evaluate()
         self._add_attributes_to_node(node)
+        if node.is_null_node:
+            node.remove()

--- a/mxslc/mxslc/TokenReader.py
+++ b/mxslc/mxslc/TokenReader.py
@@ -52,6 +52,7 @@ class TokenReader(ABC):
         Same as consume, but raise a compile error if no match was found.
         """
         token_types = _flatten(token_types)
+        assert len(token_types) > 0, "No token to match against."
         if token := self._consume(token_types):
             return token
         # raise compile error if not a match

--- a/mxslc/mxslc/compile.py
+++ b/mxslc/mxslc/compile.py
@@ -22,9 +22,6 @@ def _load_standard_library() -> None:
     document = Document()
     document.load_standard_library()
     for nd in document.node_defs:
-        # TODO add support for multiple return values
-        if nd.output_count > 1:
-            continue
         if not nd.is_default_version:
             continue
         function = NodeGraphFunction.from_node_def(nd)

--- a/mxslc/mxslc/compile_file.py
+++ b/mxslc/mxslc/compile_file.py
@@ -18,7 +18,8 @@ def compile_file(mxsl_path: str | Path,
                  main_func: str = None,
                  main_args: Sequence[Value] = None,
                  add_include_dirs: Sequence[Path] = None,
-                 add_macros: Sequence[str | Macro] = None) -> None:
+                 add_macros: Sequence[str | Macro] = None,
+                 validate=False) -> None:
     main_args = main_args or []
     add_include_dirs = add_include_dirs or []
     add_macros = add_macros or []
@@ -41,9 +42,11 @@ def compile_file(mxsl_path: str | Path,
         _call_main(mxsl_filepath, main_func, main_args)
         post_process()
 
-        success, message = get_document().validate()
-        if not success:
-            raise CompileError(message)
+        if validate:
+            success, message = get_document().validate()
+            if not success:
+                message += "\n" + get_document().xml
+                raise CompileError(message)
 
         with open(mtlx_filepath, "w") as file:
             file.write(get_document().xml)

--- a/mxslc/mxslc/mx_wrapper.py
+++ b/mxslc/mxslc/mx_wrapper.py
@@ -484,6 +484,9 @@ class Node(InterfaceElement):
     def remove(self) -> None:
         self.parent.remove_node(self.name)
 
+    def get_node_def(self) -> NodeDef:
+        return NodeDef(self.source.getNodeDef())
+
 
 #
 #   Input

--- a/mxslc/mxslc/mx_wrapper.py
+++ b/mxslc/mxslc/mx_wrapper.py
@@ -398,6 +398,11 @@ class Document(GraphElement):
     def source(self) -> mx.Document:
         return super().source
 
+    def validate(self) -> tuple[bool, str]:
+        tmp = Document(self.xml)
+        tmp.load_standard_library()
+        return tmp.source.validate()
+
     def add_node_def(self, name: str, data_type: DataType, node_name: str) -> NodeDef:
         assert name.startswith("ND_")
         name = self.create_valid_child_name(name)

--- a/mxslc/mxslc/mx_wrapper.py
+++ b/mxslc/mxslc/mx_wrapper.py
@@ -469,6 +469,18 @@ class Node(InterfaceElement):
             self.source.setName(name)
 
     @property
+    def data_type(self) -> DataType:
+        type_string = self.source.getType()
+        if type_string == "multioutput":
+            return VOID
+        else:
+            return DataType(type_string)
+
+    @data_type.setter
+    def data_type(self, data_type: DataType | str) -> None:
+        self.source.setType(str(data_type))
+
+    @property
     def is_null_node(self) -> bool:
         return self.category == Keyword.NULL
 

--- a/mxslc/mxslc/parse.py
+++ b/mxslc/mxslc/parse.py
@@ -3,6 +3,7 @@ from .Attribute import Attribute
 from .CompileError import CompileError
 from .Expressions import *
 from .Expressions.LiteralExpression import NullExpression
+from .Expressions.VariableDeclarationExpression import VariableDeclarationExpression
 from .Keyword import Keyword
 from .Parameter import Parameter
 from .Statements import *
@@ -356,4 +357,10 @@ class Parser(TokenReader):
             self._match("=")
         else:
             name = None
-        return Argument(self.__expression(), index, name)
+        return Argument(self.__argument_expression(), index, name)
+
+    def __argument_expression(self) -> Expression:
+        if self._peek() in Keyword.DATA_TYPES() and self._peek_next() == IDENTIFIER:
+            return VariableDeclarationExpression(self._consume(), self._consume())
+        else:
+            return self.__expression()

--- a/mxslc/mxslc/state.py
+++ b/mxslc/mxslc/state.py
@@ -81,7 +81,7 @@ class State(ABC):
 
     def get_function(self, identifier: str | Token, template_type: DataType = None, valid_types: set[DataType] = None, args: list[Argument] = None) -> Function:
         identifier, name = _handle_identifier(identifier)
-        matching_funcs = self.__get_functions(name, template_type, valid_types, args)
+        matching_funcs = self.get_functions(name, template_type, valid_types, args)
         if len(matching_funcs) == 0:
             raise CompileError(f"Function signature '{utils.format_function(valid_types, name, template_type, args)}' does not exist.", identifier)
         elif len(matching_funcs) == 1:
@@ -99,7 +99,7 @@ class State(ABC):
 
     def get_function_parameter_types(self, valid_types: set[DataType], identifier: str | Token, template_type: DataType, args: list[Argument], param_index: int | str) -> set[DataType]:
         identifier, name = _handle_identifier(identifier)
-        matching_funcs = self.__get_functions(name, template_type, valid_types, args, strict_args=False)
+        matching_funcs = self.get_functions(name, template_type, valid_types, args, strict_args=False)
         return {
             f.parameters[param_index].data_type
             for f
@@ -107,7 +107,7 @@ class State(ABC):
             if param_index in f.parameters
         }
 
-    def __get_functions(self, name: str, template_type: DataType = None, valid_types: set[DataType] = None, args: list[Argument] = None, strict_args=True) -> list[Function]:
+    def get_functions(self, name: str, template_type: DataType = None, valid_types: set[DataType] = None, args: list[Argument] = None, strict_args=True) -> list[Function]:
         matching_funcs = [
             f
             for f
@@ -116,7 +116,7 @@ class State(ABC):
         ]
         if len(matching_funcs) == 0:
             if self.parent:
-                return self.parent.__get_functions(name, template_type, valid_types, args, strict_args)
+                return self.parent.get_functions(name, template_type, valid_types, args, strict_args)
             else:
                 return []
         else:
@@ -337,6 +337,9 @@ def get_function(identifier: str | Token, template_type: DataType = None, valid_
 def get_function_parameter_types(valid_types: set[DataType], identifier: str | Token, template_type: DataType, args: list[Argument], param_index: int | str) -> set[DataType]:
     return _state.get_function_parameter_types(valid_types, identifier, template_type, args, param_index)
 
+
+def get_functions(name: str, template_type: DataType = None, valid_types: set[DataType] = None, args: list[Argument] = None, strict_args=True) -> list[Function]:
+    return _state.get_functions(name, template_type, valid_types, args, strict_args)
 
 def is_function(identifier: str | Token) -> bool:
     try:

--- a/mxslc/mxslc/utils.py
+++ b/mxslc/mxslc/utils.py
@@ -3,6 +3,8 @@ from typing import Sequence, Generator, Any
 
 from .DataType import DataType, FLOAT, VECTOR2, VECTOR3, VECTOR4, COLOR4, COLOR3, DATA_TYPES
 
+type Argument = Any
+
 
 def type_of_swizzle(swizzle: str) -> DataType:
     is_vector_swizzle = re.match(r"[xyzw]", swizzle)
@@ -37,13 +39,13 @@ def string(value: Any) -> str | None:
 def format_types(types: set[DataType]) -> str:
     if len(types) == 1:
         return str(list(types)[0])
-    elif types == DATA_TYPES:
+    elif DATA_TYPES.issubset(types):
         return "any"
     else:
         return f"<{', '.join([str(t) for t in types])}>"
 
 
-def format_function(return_types: set[DataType] | None, name: str, template_type: DataType | None, args: list["Argument"] | None) -> str:
+def format_function(return_types: set[DataType] | None, name: str, template_type: DataType | None, args: list[Argument] | None) -> str:
     output = ""
     if return_types:
         output += format_types(return_types) + " "

--- a/mxslc/tests/data/error/inline_with_attribs.mxsl
+++ b/mxslc/tests/data/error/inline_with_attribs.mxsl
@@ -1,0 +1,7 @@
+@doc "adds one to in"
+inline float add_one(float in)
+{
+    return in + 1.0;
+}
+
+float x = add_one(2.0);

--- a/mxslc/tests/data/error/out_param_1.mxsl
+++ b/mxslc/tests/data/error/out_param_1.mxsl
@@ -1,0 +1,10 @@
+void sincos(float r, out float s = 3.0, out float c)
+{
+    s = sin(r);
+    c = cos(r);
+}
+
+float s = 0.0;
+float c = 0.0;
+sincos(3.14, s, c);
+float x = s + c;

--- a/mxslc/tests/data/error/out_param_2.mxsl
+++ b/mxslc/tests/data/error/out_param_2.mxsl
@@ -1,0 +1,10 @@
+void sincos(float r, out float s, out float c)
+{
+    s = sin(r);
+    c = cos(r);
+}
+
+float s = 0.0;
+float c = 0.0;
+sincos(3.14, s, 7.0);
+float x = s + c;

--- a/mxslc/tests/data/mtlx/decompiler/boombox.mtlx
+++ b/mxslc/tests/data/mtlx/decompiler/boombox.mtlx
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709" fileprefix="boombox/">
+  <gltf_colorimage name="image_basecolor" type="multioutput">
+    <input name="file" type="filename" value="BoomBox_baseColor.png" colorspace="srgb_texture" />
+  </gltf_colorimage>
+  <gltf_image name="image_orm" type="vector3">
+    <input name="file" type="filename" value="BoomBox_occlusionRoughnessMetallic.png" />
+  </gltf_image>
+  <gltf_normalmap name="image_normal" type="vector3">
+    <input name="file" type="filename" value="BoomBox_normal.png" />
+  </gltf_normalmap>
+  <gltf_image name="image_emission" type="color3">
+    <input name="file" type="filename" value="BoomBox_emissive.png" colorspace="srgb_texture" />
+  </gltf_image>
+  <separate3 name="image_orm_channels" type="multioutput">
+    <input name="in" type="vector3" nodename="image_orm" />
+  </separate3>
+  <gltf_pbr name="SR_boombox" type="surfaceshader">
+    <input name="base_color" type="color3" nodename="image_basecolor" output="outcolor" />
+    <input name="alpha" type="float" nodename="image_basecolor" output="outa" />
+    <input name="metallic" type="float" nodename="image_orm_channels" output="outz" />
+    <input name="roughness" type="float" nodename="image_orm_channels" output="outy" />
+    <input name="occlusion" type="float" nodename="image_orm_channels" output="outx" />
+    <input name="normal" type="vector3" nodename="image_normal" />
+    <input name="emissive" type="color3" nodename="image_emission" />
+  </gltf_pbr>
+  <surfacematerial name="Material_boombox" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_boombox" />
+  </surfacematerial>
+</materialx>

--- a/mxslc/tests/data/mtlx/inline_out_param_1.mtlx
+++ b/mxslc/tests/data/mtlx/inline_out_param_1.mtlx
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <add name="x" type="float">
+    <input name="in1" type="float" value="1" />
+    <input name="in2" type="float" value="1" />
+  </add>
+</materialx>

--- a/mxslc/tests/data/mtlx/node_constructors_1.mtlx
+++ b/mxslc/tests/data/mtlx/node_constructors_1.mtlx
@@ -4,23 +4,26 @@
     <input name="geomprop" type="string" value="uv2" />
   </geompropvalue>
   <fractal3d name="fractal" type="vector3">
-    <input name="amplitude" type="float" value="2" />
+    <input name="amplitude" type="vector3" nodename="node4" />
     <input name="octaves" type="integer" value="3" />
-    <input name="dimish" type="float" value="0.6" />
+    <input name="diminish" type="float" value="0.6" />
   </fractal3d>
-  <position name="node6" type="vector3" />
-  <normal name="node7" type="vector3" />
-  <multiply name="node8" type="vector3">
-    <input name="in1" type="vector3" nodename="node6" />
-    <input name="in2" type="vector3" nodename="node7" />
+  <convert name="node4" type="vector3">
+    <input name="in" type="float" value="2" />
+  </convert>
+  <position name="node7" type="vector3" />
+  <normal name="node8" type="vector3" />
+  <multiply name="node9" type="vector3">
+    <input name="in1" type="vector3" nodename="node7" />
+    <input name="in2" type="vector3" nodename="node8" />
   </multiply>
-  <divide name="node10" type="vector3">
-    <input name="in1" type="vector3" nodename="node8" />
+  <divide name="node11" type="vector3">
+    <input name="in1" type="vector3" nodename="node9" />
     <input name="in2" type="float" value="2" />
   </divide>
   <add name="fractal2" type="vector3">
     <input name="in1" type="vector3" nodename="fractal" />
-    <input name="in2" type="vector3" nodename="node10" />
+    <input name="in2" type="vector3" nodename="node11" />
   </add>
   <convert name="out_color" type="color3">
     <input name="in" type="vector3" nodename="fractal2" />

--- a/mxslc/tests/data/mtlx/out_params/out_param_1.mtlx
+++ b/mxslc/tests/data/mtlx/out_params/out_param_1.mtlx
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <nodedef name="ND_sincos" node="sincos">
+    <input name="r" type="float" value="0" />
+    <output name="s" type="float" default="0.0" />
+    <output name="c" type="float" default="0.0" />
+  </nodedef>
+  <nodegraph name="NG_sincos" nodedef="ND_sincos">
+    <output name="s" type="float" nodename="s3" />
+    <output name="c" type="float" nodename="c3" />
+    <sin name="s3" type="float">
+      <input name="in" type="float" interfacename="r" />
+    </sin>
+    <cos name="c3" type="float">
+      <input name="in" type="float" interfacename="r" />
+    </cos>
+  </nodegraph>
+  <sincos name="node4" type="multioutput">
+    <input name="r" type="float" value="3.14" />
+    <output name="s" type="float" />
+    <output name="c" type="float" />
+  </sincos>
+  <add name="x" type="float">
+    <input name="in1" type="float" output="s" nodename="node4" />
+    <input name="in2" type="float" output="c" nodename="node4" />
+  </add>
+</materialx>

--- a/mxslc/tests/data/mtlx/out_params/out_param_2.mtlx
+++ b/mxslc/tests/data/mtlx/out_params/out_param_2.mtlx
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <nodedef name="ND_sincos" node="sincos">
+    <input name="r" type="float" value="0" />
+    <output name="s" type="float" default="0.0" />
+    <output name="c" type="float" default="0.0" />
+  </nodedef>
+  <nodegraph name="NG_sincos" nodedef="ND_sincos">
+    <output name="s" type="float" nodename="s3" />
+    <output name="c" type="float" nodename="c3" />
+    <sin name="s3" type="float">
+      <input name="in" type="float" interfacename="r" />
+    </sin>
+    <cos name="c3" type="float">
+      <input name="in" type="float" interfacename="r" />
+    </cos>
+  </nodegraph>
+  <sincos name="node4" type="multioutput">
+    <input name="r" type="float" value="3.14" />
+    <output name="s" type="float" />
+    <output name="c" type="float" />
+  </sincos>
+  <add name="node7" type="float">
+    <input name="in1" type="float" output="s" nodename="node4" />
+    <input name="in2" type="float" output="c" nodename="node4" />
+  </add>
+  <add name="x" type="float">
+    <input name="in1" type="float" nodename="node7" />
+    <input name="in2" type="float" value="9" />
+  </add>
+</materialx>

--- a/mxslc/tests/data/mtlx/out_params/out_param_3.mtlx
+++ b/mxslc/tests/data/mtlx/out_params/out_param_3.mtlx
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <nodedef name="ND_sincos" node="sincos">
+    <output name="s" type="float" default="0.0" />
+    <output name="c" type="float" default="0.0" />
+    <input name="r" type="float" value="0" />
+  </nodedef>
+  <nodegraph name="NG_sincos" nodedef="ND_sincos">
+    <output name="s" type="float" nodename="s3" />
+    <output name="c" type="float" nodename="c3" />
+    <sin name="s3" type="float">
+      <input name="in" type="float" interfacename="r" />
+    </sin>
+    <cos name="c3" type="float">
+      <input name="in" type="float" interfacename="r" />
+    </cos>
+  </nodegraph>
+  <sincos name="node3" type="multioutput">
+    <input name="r" type="float" value="3.14" />
+    <output name="s" type="float" />
+    <output name="c" type="float" />
+  </sincos>
+  <add name="x" type="float">
+    <input name="in1" type="float" output="s" nodename="node3" />
+    <input name="in2" type="float" output="c" nodename="node3" />
+  </add>
+</materialx>

--- a/mxslc/tests/data/mtlx/out_params/out_param_4.mtlx
+++ b/mxslc/tests/data/mtlx/out_params/out_param_4.mtlx
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <nodedef name="ND_sincos" node="sincos">
+    <output name="s" type="float" default="0.0" />
+    <input name="r" type="float" value="0" />
+    <input name="c" type="float" value="0" />
+    <output name="c2" type="float" default="0.0" />
+  </nodedef>
+  <nodegraph name="NG_sincos" nodedef="ND_sincos">
+    <output name="s" type="float" nodename="s3" />
+    <sin name="s3" type="float">
+      <input name="in" type="float" interfacename="r" />
+    </sin>
+    <cos name="node5" type="float">
+      <input name="in" type="float" interfacename="r" />
+    </cos>
+    <output name="c2" type="float" nodename="node5" />
+  </nodegraph>
+  <sincos name="node2" type="multioutput">
+    <input name="r" type="float" value="3.14" />
+    <input name="c" type="float" value="0" />
+    <output name="s" type="float" />
+    <output name="c2" type="float" />
+  </sincos>
+  <add name="x" type="float">
+    <input name="in1" type="float" output="s" nodename="node2" />
+    <input name="in2" type="float" output="c2" nodename="node2" />
+  </add>
+</materialx>

--- a/mxslc/tests/data/mtlx/out_params/out_param_5.mtlx
+++ b/mxslc/tests/data/mtlx/out_params/out_param_5.mtlx
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <nodedef name="ND_sincos" node="sincos" nodegroup="math">
+    <output name="out" type="color3" default="0, 0, 0" />
+    <input name="g" type="float" value="0" />
+    <output name="s" type="float" default="0.0" doc="sin wave" />
+    <input name="r" type="float" value="0" />
+    <input name="c" type="float" value="0" />
+    <output name="c2" type="float" default="0.0" />
+  </nodedef>
+  <nodegraph name="NG_sincos" nodedef="ND_sincos">
+    <output name="s" type="float" nodename="s3" />
+    <subtract name="node4" type="float">
+      <input name="in1" type="float" interfacename="r" />
+      <input name="in2" type="float" interfacename="g" />
+    </subtract>
+    <sin name="s3" type="float">
+      <input name="in" type="float" nodename="node4" />
+    </sin>
+    <divide name="node8" type="float">
+      <input name="in1" type="float" interfacename="r" />
+      <input name="in2" type="float" interfacename="g" />
+    </divide>
+    <cos name="node9" type="float">
+      <input name="in" type="float" nodename="node8" />
+    </cos>
+    <output name="c2" type="float" nodename="node9" />
+    <output name="out" type="color3" value="1, 0, 0" />
+  </nodegraph>
+  <sincos name="node3" type="multioutput">
+    <input name="g" type="float" value="4.2" />
+    <input name="r" type="float" value="3.14" />
+    <input name="c" type="float" value="0" />
+    <output name="out" type="color3" />
+    <output name="s" type="float" />
+    <output name="c2" type="float" />
+  </sincos>
+  <add name="x" type="float">
+    <input name="in1" type="float" output="s" nodename="node3" />
+    <input name="in2" type="float" output="c2" nodename="node3" />
+  </add>
+</materialx>

--- a/mxslc/tests/data/mtlx/out_params/out_param_6.mtlx
+++ b/mxslc/tests/data/mtlx/out_params/out_param_6.mtlx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <sin name="s4" type="float">
+    <input name="in" type="float" value="3.14" />
+  </sin>
+  <cos name="c4" type="float">
+    <input name="in" type="float" value="3.14" />
+  </cos>
+  <add name="x" type="float">
+    <input name="in1" type="float" nodename="s4" />
+    <input name="in2" type="float" nodename="c4" />
+  </add>
+</materialx>

--- a/mxslc/tests/data/mtlx/out_params/out_param_7.mtlx
+++ b/mxslc/tests/data/mtlx/out_params/out_param_7.mtlx
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <subtract name="node3" type="float">
+    <input name="in1" type="float" value="3.14" />
+    <input name="in2" type="float" value="4.2" />
+  </subtract>
+  <sin name="s4" type="float">
+    <input name="in" type="float" nodename="node3" />
+  </sin>
+  <divide name="node6" type="float">
+    <input name="in1" type="float" value="3.14" />
+    <input name="in2" type="float" value="4.2" />
+  </divide>
+  <cos name="c2" type="float">
+    <input name="in" type="float" nodename="node6" />
+  </cos>
+  <randomfloat name="node12" type="float">
+    <input name="in" type="integer" value="1" />
+  </randomfloat>
+  <combine3 name="my_color" type="color3">
+    <input name="in1" type="float" value="1" />
+    <input name="in2" type="float" nodename="node12" />
+    <input name="in3" type="float" value="0" />
+  </combine3>
+  <extract name="node14" type="float">
+    <input name="in" type="color3" nodename="my_color" />
+    <input name="index" type="integer" value="0" />
+  </extract>
+  <multiply name="node15" type="float">
+    <input name="in1" type="float" nodename="c2" />
+    <input name="in2" type="float" nodename="node14" />
+  </multiply>
+  <add name="x" type="float">
+    <input name="in1" type="float" nodename="s4" />
+    <input name="in2" type="float" nodename="node15" />
+  </add>
+</materialx>

--- a/mxslc/tests/data/mtlx/separate2.mtlx
+++ b/mxslc/tests/data/mtlx/separate2.mtlx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <texcoord name="uv" type="vector2" />
+  <separate2 name="node4" type="multioutput">
+    <input name="in" type="vector2" nodename="uv" />
+    <output name="outx" type="float" />
+    <output name="outy" type="float" />
+  </separate2>
+  <add name="x" type="float">
+    <input name="in1" type="float" output="outx" nodename="node4" />
+    <input name="in2" type="float" output="outy" nodename="node4" />
+  </add>
+</materialx>

--- a/mxslc/tests/data/mxsl/decompiler/boombox.mxsl
+++ b/mxslc/tests/data/mxsl/decompiler/boombox.mxsl
@@ -1,0 +1,7 @@
+gltf_colorimage(outcolor=color3 image_basecolor_outcolor, outa=float image_basecolor_outa, file="BoomBox_baseColor.png");
+vector3 image_orm = gltf_image(file="BoomBox_occlusionRoughnessMetallic.png");
+vector3 image_normal = gltf_normalmap(file="BoomBox_normal.png");
+color3 image_emission = gltf_image(file="BoomBox_emissive.png");
+separate3(outx=float image_orm_channels_outx, outy=float image_orm_channels_outy, outz=float image_orm_channels_outz, in=image_orm);
+surfaceshader SR_boombox = gltf_pbr(base_color=image_basecolor_outcolor, alpha=image_basecolor_outa, metallic=image_orm_channels_outz, roughness=image_orm_channels_outy, occlusion=image_orm_channels_outx, normal=image_normal, emissive=image_emission);
+material Material_boombox = surfacematerial(surfaceshader=SR_boombox);

--- a/mxslc/tests/data/mxsl/inline_out_param_1.mxsl
+++ b/mxslc/tests/data/mxsl/inline_out_param_1.mxsl
@@ -1,0 +1,10 @@
+inline void foo(out float a, out float b)
+{
+    a = 1.0;
+    b = 1.0;
+}
+
+float c = 0.0;
+float d = 0.0;
+foo(c, d);
+float x = c + d;

--- a/mxslc/tests/data/mxsl/node_constructors_1.mxsl
+++ b/mxslc/tests/data/mxsl/node_constructors_1.mxsl
@@ -1,8 +1,8 @@
 vec2 uv2 = {"geompropvalue", vec2: geomprop="uv2"};
 vec3 fractal = {"fractal3d", vec3:
-    amplitude = 2.0,
+    amplitude = vec3(2.0),
     octaves = 3,
-    dimish = 0.6
+    diminish = 0.6
 };
 
 fractal += {"position", vec3} * {"normal", vec3} / 2.0;

--- a/mxslc/tests/data/mxsl/out_params/out_param_1.mxsl
+++ b/mxslc/tests/data/mxsl/out_params/out_param_1.mxsl
@@ -1,0 +1,10 @@
+void sincos(float r, out float s, out float c)
+{
+    s = sin(r);
+    c = cos(r);
+}
+
+float s = 0.0;
+float c = 0.0;
+sincos(3.14, s, c);
+float x = s + c;

--- a/mxslc/tests/data/mxsl/out_params/out_param_2.mxsl
+++ b/mxslc/tests/data/mxsl/out_params/out_param_2.mxsl
@@ -1,0 +1,12 @@
+float s = 9.0;
+
+void sincos(float r, out float s, out float c)
+{
+    s = sin(r);
+    c = cos(r);
+}
+
+float u = 0.0;
+float v = 0.0;
+sincos(3.14, u, v);
+float x = u + v + s;

--- a/mxslc/tests/data/mxsl/out_params/out_param_3.mxsl
+++ b/mxslc/tests/data/mxsl/out_params/out_param_3.mxsl
@@ -1,0 +1,12 @@
+float r = 3.14;
+
+void sincos(out float s, out float c)
+{
+    s = sin(r);
+    c = cos(r);
+}
+
+float u = 0.0;
+float v = 0.0;
+sincos(u, v);
+float x = u + v;

--- a/mxslc/tests/data/mxsl/out_params/out_param_4.mxsl
+++ b/mxslc/tests/data/mxsl/out_params/out_param_4.mxsl
@@ -1,0 +1,11 @@
+float r = 3.14;
+float c = 0.0;
+void sincos(out float s)
+{
+    s = sin(r);
+    c = cos(r);
+}
+
+float s = 0.0;
+sincos(s);
+float x = s + c;

--- a/mxslc/tests/data/mxsl/out_params/out_param_5.mxsl
+++ b/mxslc/tests/data/mxsl/out_params/out_param_5.mxsl
@@ -1,0 +1,15 @@
+float r = 3.14;
+float c = 0.0;
+
+@nodegroup "math"
+@s.doc "sin wave"
+color3 sincos(float g, out float s)
+{
+    s = sin(r - g);
+    c = cos(r / g);
+    return color3(1.0, 0.0, 0.0);
+}
+
+float s = 0.0;
+auto my_color = sincos(4.2, s);
+float x = s + c;

--- a/mxslc/tests/data/mxsl/out_params/out_param_6.mxsl
+++ b/mxslc/tests/data/mxsl/out_params/out_param_6.mxsl
@@ -1,0 +1,10 @@
+inline void sincos(float r, out float s, out float c)
+{
+    s = sin(r);
+    c = cos(r);
+}
+
+float s = 0.0;
+float c = 0.0;
+sincos(3.14, s, c);
+float x = s + c;

--- a/mxslc/tests/data/mxsl/out_params/out_param_7.mxsl
+++ b/mxslc/tests/data/mxsl/out_params/out_param_7.mxsl
@@ -1,0 +1,13 @@
+float r = 3.14;
+float c = 0.0;
+
+inline color3 sincos(float g, out float s)
+{
+    s = sin(r - g);
+    c = cos(r / g);
+    return color3(1.0, randomfloat(1), 0.0);
+}
+
+float s = 0.0;
+auto my_color = sincos(4.2, s);
+float x = s + c * my_color.r;

--- a/mxslc/tests/data/mxsl/separate2.mxsl
+++ b/mxslc/tests/data/mxsl/separate2.mxsl
@@ -1,0 +1,7 @@
+
+vec2 uv = texcoord();
+
+float u = 0.0;
+float v = 0.0;
+separate2(u, v, uv);
+float x = u + v;

--- a/mxslc/tests/test_compile_file_args.py
+++ b/mxslc/tests/test_compile_file_args.py
@@ -31,7 +31,7 @@ def test_main_function(filename: str, main_function: str | None, main_args: list
         warn(f"Expected data for {filename} is being overwritten.")
         actual_path = expected_path
 
-    mxslc.compile_file(mxsl_path, actual_path, main_func=main_function, main_args=main_args)
+    mxslc.compile_file(mxsl_path, actual_path, main_func=main_function, main_args=main_args, validate=True)
 
     with open(actual_path, "r") as f:
         actual = f.read()

--- a/mxslc/tests/test_decompiler.py
+++ b/mxslc/tests/test_decompiler.py
@@ -45,5 +45,5 @@ def test_decompiler(filename: str, overwrite_expected: bool) -> None:
     # 2nd test - compile the decompiled shader
     mxsl_path = expected_path
     actual_path = (Path(__file__).parent / "data" / "mxsl" / filename).with_suffix(".mtlx")
-    mxslc.compile_file(mxsl_path, actual_path)
+    mxslc.compile_file(mxsl_path, actual_path, validate=True)
     actual_path.unlink()

--- a/mxslc/tests/test_decompiler.py
+++ b/mxslc/tests/test_decompiler.py
@@ -19,6 +19,7 @@ _overwrite_all_expected = False
     ("decompiler/squares", False),
     ("decompiler/toon", False),
     ("decompiler/waves", False),
+    ("decompiler/boombox", False),
 ])
 def test_decompiler(filename: str, overwrite_expected: bool) -> None:
     mtlx_path     = (Path(__file__).parent / "data" / "mtlx" / filename).with_suffix(".mtlx")

--- a/mxslc/tests/test_main.py
+++ b/mxslc/tests/test_main.py
@@ -14,7 +14,7 @@ def test_main_with_args():
     main_args = ["0.6", "tangent", "some/fake/path/butterfly1.png"]
     macro1 = ["SRGB"]
     macro2 = ["GAMMA", "2.2"]
-    main._main([mxsl_path, "-o", output_path, "-m", main_func, "-a", *main_args, "-d", *macro1, "-d", *macro2])
+    main._main([mxsl_path, "-o", output_path, "-m", main_func, "-a", *main_args, "-d", *macro1, "-d", *macro2, "-v"])
 
     actual_path = Path(__file__).parent / "data" / "mtlx" / "main_1.mtlx"
     with open(actual_path, "r") as f:

--- a/mxslc/tests/test_mxslc.py
+++ b/mxslc/tests/test_mxslc.py
@@ -89,6 +89,13 @@ _overwrite_all_expected = False
     ("inline/inline_test_8", False),
     ("inline/inline_test_9", False),
     ("inline/inline_template_test", False),
+    ("out_params/out_param_1", False),
+    ("out_params/out_param_2", False),
+    ("out_params/out_param_3", False),
+    ("out_params/out_param_4", False),
+    ("out_params/out_param_5", False),
+    ("out_params/out_param_6", False),
+    ("out_params/out_param_7", False),
 ])
 def test_mxslc(filename: str, overwrite_expected: bool) -> None:
     mxsl_path     = (Path(__file__).parent / "data" / "mxsl" / filename).with_suffix(".mxsl")

--- a/mxslc/tests/test_mxslc.py
+++ b/mxslc/tests/test_mxslc.py
@@ -97,6 +97,7 @@ _overwrite_all_expected = False
     ("out_params/out_param_6", False),
     ("out_params/out_param_7", False),
     ("separate2", False),
+    ("inline_out_param_1", False),
 ])
 def test_mxslc(filename: str, overwrite_expected: bool) -> None:
     mxsl_path     = (Path(__file__).parent / "data" / "mxsl" / filename).with_suffix(".mxsl")

--- a/mxslc/tests/test_mxslc.py
+++ b/mxslc/tests/test_mxslc.py
@@ -96,6 +96,7 @@ _overwrite_all_expected = False
     ("out_params/out_param_5", False),
     ("out_params/out_param_6", False),
     ("out_params/out_param_7", False),
+    ("separate2", False),
 ])
 def test_mxslc(filename: str, overwrite_expected: bool) -> None:
     mxsl_path     = (Path(__file__).parent / "data" / "mxsl" / filename).with_suffix(".mxsl")
@@ -106,7 +107,7 @@ def test_mxslc(filename: str, overwrite_expected: bool) -> None:
         warn(f"Expected data for {filename} is being overwritten.")
         actual_path = expected_path
 
-    mxslc.compile_file(mxsl_path, actual_path)
+    mxslc.compile_file(mxsl_path, actual_path, validate=True)
 
     with open(actual_path, "r") as f:
         actual = f.read()

--- a/mxslc/tests/test_mxslc_compile_error.py
+++ b/mxslc/tests/test_mxslc_compile_error.py
@@ -28,6 +28,9 @@ from mxslc.CompileError import CompileError
     ("bad_template_3", None, []),
     ("bad_arguments_1", None, []),
     ("keyword_as_identifier", None, []),
+    ("inline_with_attribs", None, []),
+    ("out_param_1", None, []),
+    ("out_param_2", None, []),
 ])
 def test_mxslc_compile_error(filename: str, main_function: str | None, main_args: list) -> None:
     mxsl_path = (Path(__file__).parent / "data" / "error" / filename).with_suffix(".mxsl")

--- a/mxslc/tests/test_mxslc_compile_error.py
+++ b/mxslc/tests/test_mxslc_compile_error.py
@@ -37,6 +37,6 @@ def test_mxslc_compile_error(filename: str, main_function: str | None, main_args
     mtlx_path = (Path(__file__).parent / "data" / "error" / filename).with_suffix(".mtlx")
 
     with pytest.raises(CompileError):
-        mxslc.compile_file(mxsl_path, main_func=main_function, main_args=main_args)
+        mxslc.compile_file(mxsl_path, main_func=main_function, main_args=main_args, validate=True)
 
     mtlx_path.unlink(missing_ok=True)

--- a/mxslc/tools.py
+++ b/mxslc/tools.py
@@ -1,0 +1,13 @@
+from mxslc.mx_wrapper import Document
+
+print("NodeDefs with multiple outputs:")
+doc = Document()
+doc.load_standard_library()
+for nd in doc.node_defs:
+    if nd.output_count > 1:
+        print()
+        print(nd)
+        for input_ in nd.inputs:
+            print(input_)
+        for output in nd.outputs:
+            print(output)


### PR DESCRIPTION
The feature adds the `out` keyword as a parameter modifier. It works as it does in GLSL and other shading languages.
Example:
```
void sincos(float r, out float s, out float c)
{
    s = sin(r);
    c = cos(r);
}

float s = 0.0;
float c = 0.0;
sincos(3.14, s, c);
float x = min(s, c);
```
I also borrowed the C# syntax of being able to declare variables directly inside the function call to reduce bloat:
```
void sincos(float r, out float s, out float c)
{
    s = sin(r);
    c = cos(r);
}

sincos(3.14, float s, float c);
float x = min(s, c);
```
The compiler and decompiler have both been updated, which also fixes issue #11 .