### PR TITLE
Add Mac build,  test and publish to Github workflows

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -20,7 +20,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -14,8 +14,15 @@ permissions:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - mac_build_and_test
   pull_request:
   workflow_dispatch:
 
@@ -213,4 +212,4 @@ jobs:
         run: |
           cd mxslc++
           pytest
-          
+

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -200,11 +200,10 @@ jobs:
           name: wheels-${{ matrix.os }}
           path: mxslc++/wheelhouse/*.whl
 
-      - name: Install dependencies
+      - name: Install pytest and MaterialX
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest
+          pip install pytest MaterialX
 
       - name: Install the built wheel
         run: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -210,4 +210,6 @@ jobs:
           python -c "import glob; import subprocess; import sys; wheel = glob.glob('mxslc++/wheelhouse/*.whl')[0]; subprocess.check_call([sys.executable, '-m', 'pip', 'install', wheel])"
       
       - name: Test with pytest
-        run: pytest
+        run: |
+          cd mxslc++
+          pytest tests/

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -212,4 +212,5 @@ jobs:
       - name: Test with pytest
         run: |
           cd mxslc++
-          pytest tests/
+          pytest
+          

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - mac_build_and_test
   pull_request:
   workflow_dispatch:
 
@@ -18,6 +19,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
 
     steps:
       - name: Check out mxslc
@@ -38,6 +40,7 @@ jobs:
           ref: v1.39.5
           path: mxslc++/external/MaterialX
 
+      # Linux Build
       - name: Build wheels on Linux
         if: runner.os == 'Linux'
         working-directory: mxslc++
@@ -86,6 +89,59 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: >
             CMAKE_ARGS="-DMTLX_ROOT=/project/external/MaterialX/install -DBUILD_TESTING=OFF"
 
+      # macOS Build
+      - name: Build wheels on macOS
+        if: runner.os == 'macOS'
+        working-directory: mxslc++
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BEFORE_ALL_MACOS: >
+            cmake
+            -S $PWD/external/MaterialX
+            -B $PWD/external/MaterialX/build
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_INSTALL_PREFIX=$PWD/external/MaterialX/install
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+            -DMATERIALX_BUILD_PYTHON=OFF
+            -DMATERIALX_BUILD_VIEWER=OFF
+            -DMATERIALX_BUILD_GRAPH_EDITOR=OFF
+            -DMATERIALX_BUILD_DOCS=OFF
+            -DMATERIALX_BUILD_GEN_GLSL=OFF
+            -DMATERIALX_BUILD_GEN_OSL=OFF
+            -DMATERIALX_BUILD_GEN_MDL=OFF
+            -DMATERIALX_BUILD_GEN_MSL=OFF
+            -DMATERIALX_BUILD_GEN_SLANG=OFF
+            -DMATERIALX_BUILD_RENDER=OFF
+            -DMATERIALX_BUILD_RENDER_PLATFORMS=OFF
+            -DMATERIALX_BUILD_OIIO=OFF
+            -DMATERIALX_BUILD_OCIO=OFF
+            -DMATERIALX_BUILD_TESTS=OFF
+            -DMATERIALX_BUILD_BENCHMARK_TESTS=OFF
+            -DMATERIALX_BUILD_OSOS=OFF
+            -DMATERIALX_BUILD_PERFETTO_TRACING=OFF
+            -DMATERIALX_BUILD_SHARED_LIBS=OFF
+            -DMATERIALX_BUILD_DATA_LIBRARY=OFF
+            -DMATERIALX_BUILD_MONOLITHIC=OFF
+            -DMATERIALX_BUILD_USE_CCACHE=OFF
+            -DMATERIALX_PYTHON_LTO=OFF
+            -DMATERIALX_INSTALL_PYTHON=OFF
+            -DMATERIALX_INSTALL_RESOURCES=OFF
+            -DMATERIALX_TEST_RENDER=OFF
+            -DMATERIALX_TEST_RENDER_GLSL=OFF
+            -DMATERIALX_TEST_REFERENCE_QUALITY=OFF
+            -DMATERIALX_WARNINGS_AS_ERRORS=OFF
+            -DMATERIALX_COVERAGE_ANALYSIS=OFF
+            -DMATERIALX_DYNAMIC_ANALYSIS=OFF
+            &&
+            cmake --build $PWD/external/MaterialX/build --config Release --target install --parallel
+
+          CIBW_ENVIRONMENT_MACOS: >
+            CMAKE_ARGS="-DMTLX_ROOT=$PWD/external/MaterialX/install -DBUILD_TESTING=OFF"
+            MACOSX_DEPLOYMENT_TARGET=11.0
+
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+
+      # Windows Build
       - name: Configure MaterialX on Windows
         if: runner.os == 'Windows'
         run: >
@@ -143,3 +199,12 @@ jobs:
         with:
           name: wheels-${{ matrix.os }}
           path: mxslc++/wheelhouse/*.whl
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Install the built wheel
+        run: pip install mxslc++/wheelhouse/*.whl
+
+      - name: Test with pytest
+        run: pytest

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -139,7 +139,7 @@ jobs:
             CMAKE_ARGS="-DMTLX_ROOT=$PWD/external/MaterialX/install -DBUILD_TESTING=OFF"
             MACOSX_DEPLOYMENT_TARGET=11.0
 
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: "arm64"
 
       # Windows Build
       - name: Configure MaterialX on Windows
@@ -200,11 +200,15 @@ jobs:
           name: wheels-${{ matrix.os }}
           path: mxslc++/wheelhouse/*.whl
 
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
 
       - name: Install the built wheel
-        run: pip install mxslc++/wheelhouse/*.whl
-
+        run: |
+          python -c "import glob; import subprocess; import sys; wheel = glob.glob('mxslc++/wheelhouse/*.whl')[0]; subprocess.check_call([sys.executable, '-m', 'pip', 'install', wheel])"
+      
       - name: Test with pytest
         run: pytest

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -17,6 +17,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
 
     steps:
       - name: Check out mxslc
@@ -86,6 +87,59 @@ jobs:
 
           CIBW_ENVIRONMENT_LINUX: >
             CMAKE_ARGS="-DMTLX_ROOT=/project/external/MaterialX/install -DBUILD_TESTING=OFF"
+
+      - name: Build wheels on macOS
+        if: runner.os == 'macOS'
+        working-directory: mxslc++
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+
+          CIBW_BEFORE_ALL_MACOS: >
+            cmake
+            -S $PWD/external/MaterialX
+            -B $PWD/external/MaterialX/build
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_INSTALL_PREFIX=$PWD/external/MaterialX/install
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+            -DMATERIALX_BUILD_PYTHON=OFF
+            -DMATERIALX_BUILD_VIEWER=OFF
+            -DMATERIALX_BUILD_GRAPH_EDITOR=OFF
+            -DMATERIALX_BUILD_DOCS=OFF
+            -DMATERIALX_BUILD_GEN_GLSL=OFF
+            -DMATERIALX_BUILD_GEN_OSL=OFF
+            -DMATERIALX_BUILD_GEN_MDL=OFF
+            -DMATERIALX_BUILD_GEN_MSL=OFF
+            -DMATERIALX_BUILD_GEN_SLANG=OFF
+            -DMATERIALX_BUILD_RENDER=OFF
+            -DMATERIALX_BUILD_RENDER_PLATFORMS=OFF
+            -DMATERIALX_BUILD_OIIO=OFF
+            -DMATERIALX_BUILD_OCIO=OFF
+            -DMATERIALX_BUILD_TESTS=OFF
+            -DMATERIALX_BUILD_BENCHMARK_TESTS=OFF
+            -DMATERIALX_BUILD_OSOS=OFF
+            -DMATERIALX_BUILD_PERFETTO_TRACING=OFF
+            -DMATERIALX_BUILD_SHARED_LIBS=OFF
+            -DMATERIALX_BUILD_DATA_LIBRARY=OFF
+            -DMATERIALX_BUILD_MONOLITHIC=OFF
+            -DMATERIALX_BUILD_USE_CCACHE=OFF
+            -DMATERIALX_PYTHON_LTO=OFF
+            -DMATERIALX_INSTALL_PYTHON=OFF
+            -DMATERIALX_INSTALL_RESOURCES=OFF
+            -DMATERIALX_TEST_RENDER=OFF
+            -DMATERIALX_TEST_RENDER_GLSL=OFF
+            -DMATERIALX_TEST_REFERENCE_QUALITY=OFF
+            -DMATERIALX_WARNINGS_AS_ERRORS=OFF
+            -DMATERIALX_COVERAGE_ANALYSIS=OFF
+            -DMATERIALX_DYNAMIC_ANALYSIS=OFF
+            &&
+            cmake --build $PWD/external/MaterialX/build --config Release --target install --parallel
+
+          CIBW_ENVIRONMENT_MACOS: >
+            CMAKE_ARGS="-DMTLX_ROOT=$PWD/external/MaterialX/install -DBUILD_TESTING=OFF"
+            MACOSX_DEPLOYMENT_TARGET=11.0
+
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
 
       - name: Configure MaterialX on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -139,7 +139,7 @@ jobs:
             CMAKE_ARGS="-DMTLX_ROOT=$PWD/external/MaterialX/install -DBUILD_TESTING=OFF"
             MACOSX_DEPLOYMENT_TARGET=11.0
 
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: "native"
 
       - name: Configure MaterialX on Windows
         if: runner.os == 'Windows'

--- a/mxslc++/python/tests/test_compile_file.py
+++ b/mxslc++/python/tests/test_compile_file.py
@@ -3,6 +3,12 @@ import mxslc
 
 from groundtruth import RANDOMFLOAT_OUTPUT
 
+def test_compile_string_to_string():
+    result = mxslc.compile_string_to_string('float f = randomfloat() + 1.0;')
+
+    assert isinstance(result, str)
+    assert result == RANDOMFLOAT_OUTPUT
+    
 
 def test_compile_file_to_string(tmp_path):
     source_path = tmp_path / "simple.mxsl"

--- a/mxslc++/python/tests/test_globals.py
+++ b/mxslc++/python/tests/test_globals.py
@@ -48,7 +48,9 @@ try:
         ])
 
         result = mxslc.compile_file_to_string(get_data_path("globals001.mxsl"), opts)
-        write_data("globals001.mtlx", result)
+        # Convert any Windows separators to Posix before compare.
+        result = result.replace("\\brick", "/brick")
+        write_data("globals001.mtlx", result)        
         assert result == get_data("globals001.mtlx")
 
     def test_globals_2():


### PR DESCRIPTION
## Update

- Add in Mac build and publish to GH workflow
  - Should be buidling ARM (M1,M2,etc) and not Intel as these are the current runners from Github.
- Add in test rule for `mxlsc++` (there are already tests for `mxlsc`)
- Patched one Python test as it is performing straight text compare and file paths may be `\` on WIndows vs `/` (Posix).

## Test Results
- Made test runs include this branch temporary. See [this run](https://github.com/kwokcb/ShadingLanguageX/actions/runs/30374874194)
- Also running as PR CI.