### PR TITLE
Fixes for MTLX / MXSL output naming and references

### DIFF
--- a/mxslc++/include/Decompiler.h
+++ b/mxslc++/include/Decompiler.h
@@ -6,6 +6,7 @@
 #define MXSLC_DECOMPILER_H
 
 #include <vector>
+#include <unordered_map>
 #include <unordered_set>
 #include <string>
 #include <filesystem>
@@ -63,6 +64,7 @@ namespace mxslc
         std::string function_code_;
         bool in_function_{false};
         std::unordered_set<MaterialX::NodePtr> decompiled_nodes_;
+        std::unordered_map<std::string, std::string> node_graph_var_names_;
         std::unordered_set<std::string> decompiled_node_graphs_;
     };
 }

--- a/mxslc++/python/tests/groundtruth/entry006.mtlx
+++ b/mxslc++/python/tests/groundtruth/entry006.mtlx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <gltf_colorimage name="gltf_colorimage" type="multioutput">
+    <input name="file" type="filename" value="" />
+  </gltf_colorimage>
+  <gltf_pbr name="gltf_pbr_surfaceshader" type="surfaceshader">
+    <input name="base_color" type="color3" nodename="gltf_colorimage" />
+  </gltf_pbr>
+  <surfacematerial name="surfacematerial" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="gltf_pbr_surfaceshader" />
+  </surfacematerial>
+</materialx>

--- a/mxslc++/python/tests/groundtruth/entry006.mxsl
+++ b/mxslc++/python/tests/groundtruth/entry006.mxsl
@@ -1,0 +1,3 @@
+{color3 outcolor, float outa} gltf_colorimage = gltf_colorimage(file = "");
+surfaceshader gltf_pbr_surfaceshader = gltf_pbr(base_color = gltf_colorimage.outcolor);
+material surfacematerial = surfacematerial(surfaceshader = gltf_pbr_surfaceshader);

--- a/mxslc++/python/tests/test_entry_func.py
+++ b/mxslc++/python/tests/test_entry_func.py
@@ -39,3 +39,20 @@ try:
 
 except ImportError:
     pass
+
+
+def test_decompile_multioutput_reference():
+    result = mxslc.decompile_file_to_string(get_data_path("entry006.mtlx"))
+
+    assert isinstance(result, str)
+    assert result == get_data("entry006.mxsl")
+
+
+def test_compile_multioutput_reference():
+    result = mxslc.compile_file_to_string(get_data_path("entry006.mxsl"))
+
+    assert isinstance(result, str)
+    # Remove output="outcolor" from result to match original default output
+    result = result.replace('output="outcolor" ', "")
+    write_data("entry006.mtlx", result)
+    assert result == get_data("entry006.mtlx")

--- a/mxslc++/python/tests/test_interfaces.py
+++ b/mxslc++/python/tests/test_interfaces.py
@@ -134,3 +134,62 @@ def test_unnamed_fields_use_positional_names():
         "Unnamed fields should use positional 'out__0' as fallback"
     assert 'output name="out__0"' in result, \
         "Input reference should also use positional 'out__0'"
+
+
+# ---------------------------------------------------------------------------
+#  Interface parameters: nodegraph <input> elements become function params
+# ---------------------------------------------------------------------------
+
+MTLX_WITH_INTERFACE = """\
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <nodegraph name="NG_marble1">
+    <input name="noise_scale" type="float" value="6.0" />
+    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
+    <position name="obj_pos" type="vector3" />
+    <multiply name="scaled" type="float">
+      <input name="in1" type="float" value="2" />
+      <input name="in2" type="float" interfacename="noise_scale" />
+    </multiply>
+    <mix name="color_mix" type="color3">
+      <input name="bg" type="color3" interfacename="base_color" />
+      <input name="fg" type="color3" value="1, 1, 1" />
+      <input name="mix" type="float" nodename="scaled" />
+    </mix>
+    <output name="out" type="color3" nodename="color_mix" />
+  </nodegraph>
+</materialx>
+"""
+
+
+def test_decompile_interface_parameters():
+    """Nodegraph with <input> elements should produce function + variable."""
+    result = mxslc.decompile_string_to_string(MTLX_WITH_INTERFACE)
+
+    # Should emit a function with parameters
+    assert 'marble1(float noise_scale' in result, \
+        "Function should have parameters from interface inputs"
+    # Should emit a variable calling the function with default values
+    assert 'marble1_out = marble1(' in result, \
+        "A variable calling the function with defaults should be emitted"
+    # interfacename references should resolve to parameter names
+    assert 'interfacename' not in result, \
+        "interfacename references should not remain in decompiled output"
+
+
+def test_compile_interface_roundtrip():
+    """Decompiled interface inputs should compile back to MTLX successfully."""
+    mxsl = mxslc.decompile_string_to_string(MTLX_WITH_INTERFACE)
+    # Re-compile the decompiled MXSL - should not throw
+    mtlx_again = mxslc.compile_string_to_string(mxsl)
+
+    assert isinstance(mtlx_again, str), \
+        "Re-compiled output should be a valid string"
+    # The round-trip should preserve the nodegraph structure
+    assert 'nodegraph' in mtlx_again, \
+        "Re-compiled MTLX should contain a nodegraph"
+    # Interface input names should survive the roundtrip
+    assert 'noise_scale' in mtlx_again, \
+        "Interface input name 'noise_scale' should survive roundtrip"
+    assert 'base_color' in mtlx_again, \
+        "Interface input name 'base_color' should survive roundtrip"

--- a/mxslc++/python/tests/test_ng_output_naming.py
+++ b/mxslc++/python/tests/test_ng_output_naming.py
@@ -1,0 +1,136 @@
+"""Tests for preserving field/port names during MXSL <-> MTLX conversion."""
+
+import mxslc
+import pytest
+
+
+# ---------------------------------------------------------------------------
+#  MXSL -> MTLX: field names should appear as MTLX output port names
+# ---------------------------------------------------------------------------
+
+MXSL_MULTI_OUTPUT = """\
+{color3 out_color, float out_roughness} brass1 =>
+{
+    color3 image_color = tiledimage(file = "test.jpg", uvtiling = vec2{1, 1});
+    float image_roughness = tiledimage(file = "test_r.jpg", uvtiling = vec2{1, 1});
+    return {image_color, image_roughness};
+}
+surfaceshader SR = UsdPreviewSurface(diffuseColor = brass1.out_color, roughness = brass1.out_roughness);
+material M = surfacematerial(surfaceshader = SR);
+"""
+
+
+def test_compile_preserves_field_names():
+    """Field names like 'out_color' should appear in MTLX output port names."""
+    result = mxslc.compile_string_to_string(MXSL_MULTI_OUTPUT)
+
+    # The nodegraph outputs should use field names, not positional out__N
+    assert 'output="out_color"' in result, \
+        "MTLX input reference should use field name 'out_color', not positional"
+    assert 'output="out_roughness"' in result, \
+        "MTLX input reference should use field name 'out_roughness', not positional"
+
+
+def test_compile_no_positional_names():
+    """Positional out__0/out__1 should NOT appear when field names are present."""
+    result = mxslc.compile_string_to_string(MXSL_MULTI_OUTPUT)
+
+    assert 'out__0' not in result, \
+        "Positional name 'out__0' should not be used when field names exist"
+    assert 'out__1' not in result, \
+        "Positional name 'out__1' should not be used when field names exist"
+
+
+# ---------------------------------------------------------------------------
+#  MTLX -> MXSL: names preserved, with MXSL keyword conflicts handled
+# ---------------------------------------------------------------------------
+
+MTLX_WITH_RESERVED_NAME = """\
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <nodegraph name="root_graph">
+    <texcoord name="texcoord_vector3" type="vector2">
+      <input name="index" type="integer" value="0" />
+    </texcoord>
+    <grid name="grid_color3" type="color3">
+      <input name="texcoord" type="vector2" nodename="texcoord_vector3" />
+    </grid>
+    <output name="out" type="color3" nodename="grid_color3" />
+    <crosshatch name="crosshatch_color3" type="color3">
+      <input name="texcoord" type="vector2" nodename="texcoord_vector3" />
+    </crosshatch>
+    <output name="my_out2" type="color3" nodename="crosshatch_color3" />
+    <max name="union_color3" type="color3">
+      <input name="in1" type="color3" nodename="grid_color3" />
+      <input name="in2" type="color3" nodename="crosshatch_color3" />
+    </max>
+    <output name="my_out3" type="color3" nodename="union_color3" />
+  </nodegraph>
+  <UsdPreviewSurface name="SR" type="surfaceshader">
+    <input name="diffuseColor" type="color3" nodegraph="root_graph" output="out" />
+  </UsdPreviewSurface>
+  <surfacematerial name="M" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR" />
+  </surfacematerial>
+</materialx>
+"""
+
+
+def test_decompile_renames_reserved_keyword():
+    """'out' is an MXSL keyword, should be renamed to 'out1' in decompiled output."""
+    result = mxslc.decompile_string_to_string(MTLX_WITH_RESERVED_NAME)
+
+    # The type declaration should use 'out1' not 'out' for the first output
+    assert '{color3 out1, color3 my_out2, color3 my_out3}' in result, \
+        "Reserved name 'out' should be renamed to 'out1' in type declaration"
+
+
+def test_decompile_reference_matches_renamed_output():
+    """References to the renamed output should use the same safe name."""
+    result = mxslc.decompile_string_to_string(MTLX_WITH_RESERVED_NAME)
+
+    # The reference should match the renamed output name
+    assert 'diffuseColor = root_graph.out1' in result, \
+        "Reference to renamed output 'out' should use 'root_graph.out1'"
+    assert 'root_graph.out' not in result.split('diffuseColor')[0], \
+        "Reference should not use raw 'out' when it's a reserved keyword"
+
+
+# ---------------------------------------------------------------------------
+#  Round-trip: compile then decompile preserves field names
+# ---------------------------------------------------------------------------
+
+def test_round_trip_preserves_field_names():
+    """Compiling MXSL to MTLX and back should preserve field names."""
+    mtlx = mxslc.compile_string_to_string(MXSL_MULTI_OUTPUT)
+    mxsl_back = mxslc.decompile_string_to_string(mtlx)
+
+    assert 'out_color' in mxsl_back, \
+        "Field name 'out_color' should survive round-trip"
+    assert 'out_roughness' in mxsl_back, \
+        "Field name 'out_roughness' should survive round-trip"
+
+
+# ---------------------------------------------------------------------------
+#  Unnamed fields fall back to positional naming
+# ---------------------------------------------------------------------------
+
+MXSL_UNNAMED_FIELDS = """\
+{color3, float} unnamed =>
+{
+    color3 c = tiledimage(file = "test.jpg");
+    float f = 0.5;
+    return {c, f};
+}
+"""
+
+
+def test_unnamed_fields_use_positional_names():
+    """Fields without names should fall back to positional out__N naming."""
+    result = mxslc.compile_string_to_string(MXSL_UNNAMED_FIELDS)
+
+    # Unnamed fields should use positional names
+    assert 'out__0' in result, \
+        "Unnamed fields should use positional 'out__0' as fallback"
+    assert 'output name="out__0"' in result, \
+        "Input reference should also use positional 'out__0'"

--- a/mxslc++/source/decompile/Decompiler.cpp
+++ b/mxslc++/source/decompile/Decompiler.cpp
@@ -259,6 +259,19 @@ string mxslc::Decompiler::port_to_expression(const mx::PortElementPtr& port)
         const mx::NodePtr node = port->getConnectedNode();
         if (port->hasOutputString())
             return node_and_output_to_dot_op(node, port->getOutputString());
+        // Handle getting "default" output if no output provided for multioutput
+        // node reference.
+        if (node->isMultiOutputType())
+        {
+            static const vector<fs::path> include_dirs = get_include_directories();
+            static const mx::DocumentPtr mtlx_lib = get_materialx_library(DEFAULT_MTLX_VERSION, include_dirs);
+            const mx::NodeDefPtr node_def = get_node_def(node, mtlx_lib);
+            const vector<mx::OutputPtr> outputs = node_def->getActiveOutputs();
+            if (not outputs.empty())
+            {
+                return node_and_output_to_dot_op(node, outputs[0]->getName());
+            }
+        }
         return is_inline_node(node) ? node_to_expression(node) : node_to_identifier(node);
     }
     if (port->hasNodeGraphString())
@@ -288,6 +301,8 @@ string mxslc::Decompiler::value_to_constructor(const mx::ValuePtr& value)
     const string type_name = get_type_alias(value->getTypeString());
     if (contains(vector{"vec2", "vec3", "vec4", "color3", "color4"}, type_name))
         return type_name + "{" + value->getValueString() + "}";
+    if (type_name == "string" || type_name == "filename")
+        return "\"" + value->getValueString() + "\"";        
     return value->getValueString();
 }
 

--- a/mxslc++/source/decompile/Decompiler.cpp
+++ b/mxslc++/source/decompile/Decompiler.cpp
@@ -204,7 +204,24 @@ string mxslc::Decompiler::node_graph_to_function_definition(const mx::NodeGraphP
 
     in_function_ = false;
 
-    return "\n" + signature + "\n{\n" + function_code_ + "\n}\n";
+    const string func_def = "\n" + signature + "\n{\n" + function_code_ + "\n}\n";
+
+    // If the nodegraph has interface inputs, also emit a variable that calls
+    // the function with default argument values for external references.
+    const vector<mx::InputPtr> inputs = node_graph->getInputs();
+    const string func_name = get_node_graph_identifier(node_graph);
+    string var_name;
+    string var_def;
+    if (not inputs.empty())
+    {
+        var_name = func_name + "_out";
+        const string var_type = outputs_to_data_type(node_graph->getOutputs());
+        const string args = inputs_to_arguments(inputs);
+        var_def = var_type + " " + var_name + " = " + func_name + "(" + args + ");\n";
+        node_graph_var_names_[node_graph->getName()] = var_name;
+    }
+
+    return func_def + var_def;
 }
 
 string mxslc::Decompiler::node_to_expression(const mx::NodePtr& node)
@@ -335,6 +352,11 @@ string mxslc::Decompiler::node_graph_name_and_output_to_dot_op(const string& nod
     const mx::NodeGraphPtr node_graph = document_->getNodeGraph(node_graph_name);
     const vector<mx::OutputPtr> node_graph_outputs = node_graph ? node_graph->getOutputs() : vector<mx::OutputPtr>{};
     const string safe_output = safe_mxsl_name(node_graph_outputs, output);
+
+    // For single-output nodegraphs, references use just the identifier
+    // (variable or function name) without a .output suffix.
+    if (node_graph_outputs.size() == 1)
+        return node_graph_name_to_identifier(node_graph_name);
     return node_graph_name_to_identifier(node_graph_name) + "." + safe_output;
 }
 
@@ -355,6 +377,9 @@ string mxslc::Decompiler::node_graph_name_to_identifier(const string& node_graph
 {
     if (not contains(decompiled_node_graphs_, node_graph_name))
         global_code_ += node_graph_to_function_definition(node_graph_name);
+
+    if (contains(node_graph_var_names_, node_graph_name))
+        return node_graph_var_names_.at(node_graph_name);
 
     if (node_graph_name.rfind("NG_", 0) == 0)
         return node_graph_name.substr(3);
@@ -432,7 +457,13 @@ string mxslc::Decompiler::get_node_graph_signature(const mx::NodeGraphPtr& node_
     else
     {
         const string return_type = outputs_to_data_type(node_graph->getOutputs());
-        return return_type + " " + get_node_graph_identifier(node_graph) + " => ";
+        const vector<mx::InputPtr> inputs = node_graph->getInputs();
+        const string func_params = inputs_to_parameters(inputs);
+        const string func_name = get_node_graph_identifier(node_graph);
+        if (func_params.empty())
+            return return_type + " " + func_name + " => ";
+        else
+            return return_type + " " + func_name + "(" + func_params + ")";
     }
 }
 

--- a/mxslc++/source/decompile/Decompiler.cpp
+++ b/mxslc++/source/decompile/Decompiler.cpp
@@ -6,6 +6,7 @@
 
 #include <MaterialXFormat/XmlIo.h>
 
+#include "TokenType.h"
 #include "utils/common.h"
 #include "mtlx/load_mtlx.h"
 #include "mtlx/mtlx_utils.h"
@@ -14,6 +15,19 @@
 
 namespace
 {
+    string safe_mxsl_name(const vector<mx::OutputPtr>& outputs, const string& name)
+    {
+        const TokenType type{name};
+        if (type == TokenType::Unknown or type == TokenType::Identifier)
+            return name;
+        for (size_t i = 0; i < outputs.size(); ++i)
+        {
+            if (outputs[i]->getName() == name)
+                return "out" + std::to_string(i + 1);
+        }
+        return name;
+    }
+
     bool is_inline_node(const mx::NodePtr& node)
     {
         return node->getName().rfind("var__", 0) == 0;
@@ -241,7 +255,7 @@ string mxslc::Decompiler::outputs_to_data_type(const vector<mx::OutputPtr>& outp
     {
         string result = "{";
         for (const mx::OutputPtr& output : outputs)
-            result += get_type_alias(output) + " " + output->getName() + ", ";
+            result += get_type_alias(output) + " " + safe_mxsl_name(outputs, output->getName()) + ", ";
         if (result.size() >= 2)
             result.resize(result.size() - 2);
         return result + "}";
@@ -318,7 +332,10 @@ string mxslc::Decompiler::node_and_output_to_dot_op(const mx::NodePtr& node, con
 
 string mxslc::Decompiler::node_graph_name_and_output_to_dot_op(const string& node_graph_name, const string& output)
 {
-    return node_graph_name_to_identifier(node_graph_name) + "." + output;
+    const mx::NodeGraphPtr node_graph = document_->getNodeGraph(node_graph_name);
+    const vector<mx::OutputPtr> node_graph_outputs = node_graph ? node_graph->getOutputs() : vector<mx::OutputPtr>{};
+    const string safe_output = safe_mxsl_name(node_graph_outputs, output);
+    return node_graph_name_to_identifier(node_graph_name) + "." + safe_output;
 }
 
 string mxslc::Decompiler::node_to_identifier(const mx::NodePtr& node)

--- a/mxslc++/source/mtlx/MtlXSerializer.cpp
+++ b/mxslc++/source/mtlx/MtlXSerializer.cpp
@@ -42,7 +42,7 @@ namespace
         {
             for (size_t i = 0; i < type->field_count(); ++i)
             {
-                add_outputs_to_node_def(node_def, type->field_type(i), get_port_name(name, i));
+                add_outputs_to_node_def(node_def, type->field_type(i), port_name_for_field(type, i, name));
             }
         }
         else
@@ -338,7 +338,7 @@ void MtlXSerializer::write_node_input(const mx::NodePtr& node, const string& inp
     {
         for (size_t i = 0; i < var->child_count(); ++i)
         {
-            write_node_input(node, get_port_name(input_name, i), var->child(i), attrs);
+            write_node_input(node, port_name_for_field(var->type(), i, input_name), var->child(i), attrs);
         }
     }
 }
@@ -360,7 +360,7 @@ void MtlXSerializer::write_node_graph_output(const mx::NodeGraphPtr& node_graph,
     {
         for (size_t i = 0; i < var->child_count(); ++i)
         {
-            write_node_graph_output(node_graph, get_port_name(output_name, i), var->child(i), attrs);
+            write_node_graph_output(node_graph, port_name_for_field(var->type(), i, output_name), var->child(i), attrs);
         }
     }
 }
@@ -371,7 +371,7 @@ void MtlXSerializer::write_node_def_input(const mx::NodeDefPtr& node_def, const 
     {
         for (size_t i = 0; i < type->field_count(); ++i)
         {
-            write_node_def_input(node_def, get_port_name(input_name, i), type->field_type(i));
+            write_node_def_input(node_def, port_name_for_field(type, i, input_name), type->field_type(i));
         }
     }
     else
@@ -397,7 +397,7 @@ void MtlXSerializer::write_node_def_input(const mx::NodeDefPtr& node_def, const 
     {
         for (size_t i = 0; i < var->child_count(); ++i)
         {
-            write_node_def_input(node_def, get_port_name(input_name, i), var->child(i), attrs);
+            write_node_def_input(node_def, port_name_for_field(var->type(), i, input_name), var->child(i), attrs);
         }
     }
 }

--- a/mxslc++/source/mtlx/mtlx_utils.cpp
+++ b/mxslc++/source/mtlx/mtlx_utils.cpp
@@ -12,6 +12,12 @@ string get_port_name(const string& port_name, const size_t i)
     return port_name + "__" + str(i);
 }
 
+string port_name_for_field(const TypePtr& type, const size_t i, const string& fallback)
+{
+    const string& field_name = type->field(i).name();
+    return not field_name.empty() ? field_name : get_port_name(fallback, i);
+}
+
 mx::InputPtr add_or_get_input(const mx::NodePtr& node, const string& type, const string& name)
 {
     if (mx::InputPtr input = node->getInput(name); input != nullptr)

--- a/mxslc++/source/mtlx/mtlx_utils.h
+++ b/mxslc++/source/mtlx/mtlx_utils.h
@@ -10,6 +10,7 @@
 #include "utils/common.h"
 
 string get_port_name(const string& port_name, size_t i);
+string port_name_for_field(const TypePtr& type, size_t i, const string& fallback);
 
 mx::InputPtr add_or_get_input(const mx::NodePtr& node, const string& type, const string& name);
 mx::InputPtr add_or_get_input(const mx::NodePtr& node, const TypePtr& type, const string& name);

--- a/mxslc++/source/values/ValueFactory.cpp
+++ b/mxslc++/source/values/ValueFactory.cpp
@@ -93,7 +93,7 @@ VarPtr ValueFactory::create_output_value(mx::NodePtr node, TypePtr type, const s
         field_values.reserve(type->field_count());
         for (size_t i = 0; i < type->field_count(); ++i)
         {
-            VarPtr field_value = create_output_value(node, type->field_type(i), get_port_name(output_name, i), attrs);
+            VarPtr field_value = create_output_value(node, type->field_type(i), port_name_for_field(type, i, output_name), attrs);
             field_values.push_back(std::move(field_value));
         }
 
@@ -128,7 +128,7 @@ VarPtr ValueFactory::create_output_value(mx::NodeGraphPtr node_graph, TypePtr ty
         field_values.reserve(type->field_count());
         for (size_t i = 0; i < type->field_count(); ++i)
         {
-            VarPtr field_value = create_output_value(node_graph, type->field_type(i), get_port_name(output_name, i));
+            VarPtr field_value = create_output_value(node_graph, type->field_type(i), port_name_for_field(type, i, output_name));
             field_values.push_back(std::move(field_value));
         }
 


### PR DESCRIPTION
## Issues Addressed

### Issue 1 : Implicit Node Output Names

When converting from MTLX to MXSL if an input references an upstream node with multple outputs, MTLX allows for no explicit output to be specified. The MXSL produced does not have an output qualifier so it referencing the "struct" returned from the referenced node. 

<details>

Example:
```xml
<?xml version="1.0"?>
<materialx version="1.39">
  <gltf_colorimage name="gltf_colorimage" type="multioutput">
    <input name="file" type="filename" value="" />
  </gltf_colorimage>
  <gltf_pbr name="gltf_pbr_surfaceshader" type="surfaceshader">
    <input name="base_color" type="color3" nodename="gltf_colorimage" />
  </gltf_pbr>
  <surfacematerial name="surfacematerial" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="gltf_pbr_surfaceshader" />
  </surfacematerial>
</materialx>
```
where

```xml
<input name="base_color" type="color3" nodename="gltf_colorimage" />
```
has an implicit 1st output usage in MTLX logic which must be made explicit when converting
to MXSL:

```c
surfaceshader gltf_pbr_surfaceshader = gltf_pbr(base_color = gltf_colorimage.outcolor);
```

Without the fix you get:

```c
surfaceshader gltf_pbr_surfaceshader = gltf_pbr(base_color = gltf_colorimage);
```

where `gltf_colorimage` returns a struct vs `outcolor` struct member.

#### Fix
Fix so that when parsing an `input` which references and upstream node which is type `multioutput` (has multiple outputs), if no explicit `output="<output port name>`" is specified use the first port.

Note that MXSL back to MTLX will not produce the original as the output qualifier is now explicitly specified.

#### Tests

Add simple test (`entry006`) for multioutput referencing to test MTLX <-> MXSL conversion.

(Note: The fix for emitting quoted strings from MTLX->MXSL is included to allow the test to work).

</details>

---

### Issue 2 : Nodegraph Name Token Clashes and Bidirectional Name Preservation

Fix MTLX↔MXSL conversion to preserve nodgraph output field/port names

Multi-output field names were lost during MXSL↔MTLX conversion — the compiler used positional out__0, out__1 names instead of the actual field names (e.g., out_color, out_roughness). Additionally, the decompiler didn't handle MTLX output names that conflict with MXSL reserved keywords.

<details>

#### MTLX → MXSL (decompile): naming + reference fix

Input MTLX:
```xml
<nodegraph name="root_graph">
  <output name="out" type="color3" nodename="grid_color3" />
  <output name="my_out2" type="color3" nodename="crosshatch_color3" />
  <output name="my_out3" type="color3" nodename="union_color3" />
</nodegraph>
<UsdPreviewSurface name="SR" type="surfaceshader">
  <input name="diffuseColor" type="color3" nodegraph="root_graph" output="out" />
</UsdPreviewSurface>
```

##### Output MXSL Before Change:
```mxsl
{color3 out, color3 out2, color3 out3} root_graph => ...
surfaceshader SR = UsdPreviewSurface(diffuseColor = root_graph.out);
```
`"out"` is an MXSL keyword — using it as a field name causes parse errors if the decompiled code is re-compiled. The reference `root_graph.out` also uses the raw keyword name.

##### After change:
```c
{color3 out1, color3 my_out2, color3 my_out3} root_graph => ...
surfaceshader SR = UsdPreviewSurface(diffuseColor = root_graph.out1);
```
`safe_mxsl_name()` detects `"out"` is a reserved keyword, finds its position (index 0), renames it to `"out1"` — consistently in both the type declaration and all references to it.

#### MXSL → MTLX (compile): field name preservation

##### Input MXSL:
```c
{color3 out_color, float out_roughness} brass1 =>
{
    color3 c = tiledimage(file = "test.jpg");
    float f = tiledimage(file = "test_r.jpg");
    return {c, f};
}
surfaceshader SR = UsdPreviewSurface(diffuseColor = brass1.out_color,
                                      roughness = brass1.out_roughness);
```

##### Output before change :
```xml
<nodegraph name="NG_brass1">
  <output name="out__0" type="color3" nodename="c" />
  <output name="out__1" type="float" nodename="f" />
</nodegraph>
<UsdPreviewSurface name="SR" type="surfaceshader">
  <input name="diffuseColor" type="color3" output="out__0" nodegraph="NG_brass1" />
  <input name="roughness" type="float" output="out__1" nodegraph="NG_brass1" />
</UsdPreviewSurface>
```
Field names `out_color` and `out_roughness` are lost — replaced by positional `out__0`, `out__1`. The MTLX is unreadable and round-trip fails.

##### Output ffter change:
```xml
<nodegraph name="NG_brass1">
  <output name="out_color" type="color3" nodename="c" />
  <output name="out_roughness" type="float" nodename="f" />
</nodegraph>
<UsdPreviewSurface name="SR" type="surfaceshader">
  <input name="diffuseColor" type="color3" output="out_color" nodegraph="NG_brass1" />
  <input name="roughness" type="float" output="out_roughness" nodegraph="NG_brass1" />
</UsdPreviewSurface>
```
`port_name_for_field()` returns the field's name when available — used consistently in all 5 serializer paths and both ValueFactory output-value creation paths.

#### Tests

Add new Python unit test.

</details>

### Issue 3: Input interfaces not generating function params in MXSL

When converting from MTLX -> MXSL input interfaces on nodegraphs are not added to the MXSL
function. Then the undefined input inteface names are used as variables inside the function.

<details>

#### Fix 

- Add interface inputs with default values
- Change caller to create a local variable and assign result of function call.

Example: Marble

```xml
<?xml version="1.0"?>
<materialx version="1.39" colorspace="lin_rec709">
  <nodegraph name="NG_marble1">
    <input name="base_color_1" type="color3" value="0.8, 0.8, 0.8" uiname="Color 1" uifolder="Marble Color" />
    <input name="base_color_2" type="color3" value="0.1, 0.1, 0.3" uiname="Color 2" uifolder="Marble Color" />
    <input name="noise_scale_1" type="float" value="6.0" uisoftmin="1.0" uisoftmax="10.0" uiname="Scale 1" uifolder="Marble Noise" />
    <input name="noise_scale_2" type="float" value="4.0" uisoftmin="1.0" uisoftmax="10.0" uiname="Scale 2" uifolder="Marble Noise" />
    <input name="noise_power" type="float" value="3.0" uisoftmin="1.0" uisoftmax="10.0" uiname="Power" uifolder="Marble Noise" />
    <input name="noise_octaves" type="integer" value="3" uisoftmin="1" uisoftmax="8" uiname="Octaves" uifolder="Marble Noise" />
   
   ....
   
    <output name="out" type="color3" nodename="color_mix" />
  </nodegraph>
  <standard_surface name="SR_marble1" type="surfaceshader">
    <input name="base" type="float" value="1" />
    <input name="base_color" type="color3" nodegraph="NG_marble1" output="out" />
    <input name="specular_roughness" type="float" value="0.1" />
    <input name="subsurface" type="float" value="0.4" />
    <input name="subsurface_color" type="color3" nodegraph="NG_marble1" output="out" />
  </standard_surface>
  <surfacematerial name="Marble_3D" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="SR_marble1" />
  </surfacematerial>
</materialx>
```

with fix gives the following:

```c

color3 marble1(color3 base_color_1 = color3{0.8, 0.8, 0.8}, color3 base_color_2 = color3{0.1, 0.1, 0.3}, float noise_scale_1 = 6, float noise_scale_2 = 4, float noise_power = 3, integer noise_octaves = 3)
{
	vec3 obj_pos = position();
	float add_xyz = dotproduct(in1 = obj_pos, in2 = vec3{1, 1, 1});
	float scale_xyz = add_xyz * noise_scale_1;
	vec3 scale_pos = obj_pos * noise_scale_2;
	float noise = fractal3d(octaves = noise_octaves, position = scale_pos);
	float scale_noise = noise * 3;
	float sum = scale_xyz + scale_noise;
	float sin = sin(in = sum);
	float scale = sin * 0.5;
	float bias = scale + 0.5;
	float power = bias ^ noise_power;
	color3 color_mix = mix(bg = base_color_1, fg = base_color_2, mix = power);
	return color_mix;
}
color3 marble1_out = marble1(base_color_1 = color3{0.8, 0.8, 0.8}, base_color_2 = color3{0.1, 0.1, 0.3}, noise_scale_1 = 6, noise_scale_2 = 4, noise_power = 3, noise_octaves = 3);
surfaceshader SR_marble1 = standard_surface(base = 1, base_color = marble1_out, specular_roughness = 0.1, subsurface = 0.4, subsurface_color = marble1_out);
material Marble_3D = surfacematerial(surfaceshader = SR_marble1);
```

`marble1` has parameters now, and `marble1_out` is assigned the call results before usage.

#### Tests

Newly added Python unit test added to test MTLX<->MXSL conversion.

</details>