### PR TITLE
Compiler: Improve default definition resolution for ambiguous MTLX function calls

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,10 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        include:
+          - os: ubuntu-latest
+          - os: windows-latest
+          - os: macos-14
+            generator: Ninja
+            cc: clang
+            cxx: clang++
 
     steps:
       - name: Check out mxslc
@@ -34,6 +37,9 @@ jobs:
       - name: Configure and Build MaterialX
         run: >
           cmake 
+          ${{ matrix.generator != '' && format('-G "{0}"', matrix.generator) || '' }}
+          ${{ matrix.cc != '' && format('-DCMAKE_C_COMPILER={0}', matrix.cc) || '' }}
+          ${{ matrix.cxx != '' && format('-DCMAKE_CXX_COMPILER={0}', matrix.cxx) || '' }}
           -S mxslc++/external/MaterialX 
           -B mxslc++/external/MaterialX/build 
           -DCMAKE_BUILD_TYPE=Release 
@@ -78,12 +84,13 @@ jobs:
         timeout-minutes: 20
         run: >
           cmake 
+          ${{ matrix.generator != '' && format('-G "{0}"', matrix.generator) || '' }}
+          ${{ matrix.cc != '' && format('-DCMAKE_C_COMPILER={0}', matrix.cc) || '' }}
+          ${{ matrix.cxx != '' && format('-DCMAKE_CXX_COMPILER={0}', matrix.cxx) || '' }}
           -S mxslc++ 
           -B mxslc++/build 
           -DCMAKE_BUILD_TYPE=Release 
-          -DMTLX_ROOT="${{ github.workspace }}/mxslc++/external/MaterialX/install" 
-          -DCMAKE_FIND_DEBUG_MODE=ON 
-          --log-level=VERBOSE
+          -DMTLX_ROOT="${{ github.workspace }}/mxslc++/external/MaterialX/install"
 
       - name: Build mxslc (C++)
         timeout-minutes: 30

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,15 +75,19 @@ jobs:
 
       - name: Configure mxslc (C++)
         # Point CMake (-S) to the mxslc++ directory where your root CMakeLists.txt resides
+        timeout-minutes: 20
         run: >
           cmake 
           -S mxslc++ 
           -B mxslc++/build 
           -DCMAKE_BUILD_TYPE=Release 
-          -DMTLX_ROOT="${{ github.workspace }}/mxslc++/external/MaterialX/install"
+          -DMTLX_ROOT="${{ github.workspace }}/mxslc++/external/MaterialX/install" 
+          -DCMAKE_FIND_DEBUG_MODE=ON 
+          --log-level=VERBOSE
 
       - name: Build mxslc (C++)
-        run: cmake --build mxslc++/build --config Release --parallel
+        timeout-minutes: 30
+        run: cmake --build mxslc++/build --config Release --parallel 2 --verbose
 
       - name: Run C++ Tests
         working-directory: ${{ github.workspace }}/mxslc++/build

--- a/mxslc++/python/tests/groundtruth/signatures.mtlx
+++ b/mxslc++/python/tests/groundtruth/signatures.mtlx
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <normalmap name="node_normalmap" type="vector3">
+    <input name="scale" type="float" value="1.0" />
+  </normalmap>
+  <normalmap name="node_normalmap2" type="vector3">
+    <input name="scale" type="float" value="1" />
+  </normalmap>
+  <normalmap name="node_normalmap3" type="vector3">
+    <input name="scale" type="vector2" value="1, 1" />
+  </normalmap>
+  <image name="node_image_vector3_10" type="vector3">
+    <input name="file" type="filename" value="test.png" />
+  </image>
+  <normalmap name="node_normalmap4" type="vector3">
+    <input name="in" type="vector3" nodename="node_image_vector3_10" />
+    <input name="scale" type="float" value="1.0" />
+  </normalmap>
+  <randomfloat name="c" type="float">
+    <input name="in" type="float" value="1" />
+  </randomfloat>
+  <randomcolor name="d" type="color3">
+    <input name="in" type="float" value="0.0" />
+  </randomcolor>
+  <randomcolor name="d2" type="color3">
+    <input name="in" type="integer" value="1" />
+  </randomcolor>
+  <randomcolor name="d3" type="color3">
+    <input name="in" type="float" value="1" />
+  </randomcolor>
+</materialx>

--- a/mxslc++/python/tests/groundtruth/signatures.mxsl
+++ b/mxslc++/python/tests/groundtruth/signatures.mxsl
@@ -1,0 +1,21 @@
+
+vec3 node_normalmap = normalmap();
+float x = node_normalmap.scale;
+vec3 node_normalmap2 = normalmap(scale=1.0);
+float x2 = node_normalmap2.scale;
+vec3 node_normalmap3 = normalmap(scale=vec2{1.0,1.0});
+vec2 x3 = node_normalmap3.scale;
+vec3 node_image_vector3_10 = image(file = "test.png");
+vec3 node_normalmap4 = normalmap(in = node_image_vector3_10);
+float y = node_normalmap4.scale;
+
+
+float c = randomfloat(1.0);
+float in2 = c.in;
+
+color3 d = randomcolor();
+float din = d.in;
+color3 d2 = randomcolor(in=1);
+int d2in = d2.in;
+color3 d3 = randomcolor(in=1.0);
+float d3in = d3.in;

--- a/mxslc++/python/tests/test_default_signatures.py
+++ b/mxslc++/python/tests/test_default_signatures.py
@@ -1,0 +1,7 @@
+import mxslc
+from data_utils import get_data_path, assert_matches_groundtruth
+
+def test_compile_signatures():    
+    result = mxslc.compile_file_to_string(get_data_path("signatures.mxsl"))
+    assert_matches_groundtruth(result, "signatures.mtlx")
+

--- a/mxslc++/source/expressions/accessors/PortAccessor.cpp
+++ b/mxslc++/source/expressions/accessors/PortAccessor.cpp
@@ -36,6 +36,11 @@ namespace mxslc::expressions
             throw CompileError{"Variable of type '" + node_var_->type()->to_string() + "' does not have a port or valid swizzle with the name: " + input_name_};
 
         input_ = mtlx_utils::add_or_get_input(node, input->getType(), input_name_);
+
+        // When the port was not set on the node, initialize it with the default
+        // value from the node definition so that reading the port yields a value.
+        if (not input_->hasValue() and input->hasValue())
+            input_->setValueString(input->getValueString());
     }
 
     TypePtr PortAccessor::type() const

--- a/mxslc++/source/expressions/accessors/PortAccessor.cpp
+++ b/mxslc++/source/expressions/accessors/PortAccessor.cpp
@@ -37,9 +37,13 @@ namespace mxslc::expressions
 
         input_ = mtlx_utils::add_or_get_input(node, input->getType(), input_name_);
 
-        // When the port was not set on the node, initialize it with the default
-        // value from the node definition so that reading the port yields a value.
-        if (not input_->hasValue() and input->hasValue())
+        // Only seed defaults for an unconnected, unset port. Connected inputs
+        // should not get a literal value injected alongside their connection.
+        if (not input_->hasValue()
+            and not input_->hasNodeName()
+            and not input_->hasNodeGraphString()
+            and not input_->hasInterfaceName()
+            and input->hasValue())
             input_->setValueString(input->getValueString());
     }
 

--- a/mxslc++/source/serialize/values/NodeOutputValue.cpp
+++ b/mxslc++/source/serialize/values/NodeOutputValue.cpp
@@ -39,6 +39,7 @@ namespace mxslc::serialize::values
 
     void NodeOutputValue::set_as_node_input(const mx::InputPtr& input) const
     {
+        input->removeAttribute("value");
         input->setOutputString(output_name_);
         input->setConnectedNode(node_);
     }

--- a/mxslc++/source/serialize/values/NodeValue.cpp
+++ b/mxslc++/source/serialize/values/NodeValue.cpp
@@ -40,6 +40,7 @@ namespace mxslc::serialize::values
 
     void NodeValue::set_as_node_input(const mx::InputPtr& input) const
     {
+        input->removeAttribute("value");
         input->setConnectedNode(node_);
     }
 

--- a/mxslc++/source/utils/load_mtlx.cpp
+++ b/mxslc++/source/utils/load_mtlx.cpp
@@ -53,7 +53,7 @@ namespace mxslc
         // they are loaded.
         unordered_set<string> get_default_node_defs(const mx::DocumentPtr& doc)
         {
-            unordered_map<string, unordered_map<string, string>> first_by_category_and_type;
+            unordered_map<string, unordered_map<string, string>> best_by_category_and_type;
             unordered_map<string, unordered_map<string, size_t>> counts_by_category_and_type;
             unordered_set<string> defaults;
 
@@ -65,22 +65,30 @@ namespace mxslc
                 const string& category = nd->getNodeString();
                 const string return_type = get_return_type_key(nd);
 
-                auto& first_by_type = first_by_category_and_type[category];
+                auto& best_by_type = best_by_category_and_type[category];
                 auto& counts_by_type = counts_by_category_and_type[category];
 
-                if (not contains(first_by_type, return_type))
-                    first_by_type.emplace(return_type, nd->getName());
+                if (not contains(best_by_type, return_type))
+                {
+                    best_by_type.emplace(return_type, nd->getName());
+                }
+                else
+                {
+                    string& best_name = best_by_type.at(return_type);
+                    if (nd->getName() < best_name)
+                        best_name = nd->getName();
+                }
 
                 ++counts_by_type[return_type];
             }
 
             for (const auto& [category, counts_by_type] : counts_by_category_and_type)
             {
-                const auto& first_by_type = first_by_category_and_type.at(category);
+                const auto& best_by_type = best_by_category_and_type.at(category);
                 for (const auto& [return_type, count] : counts_by_type)
                 {
                     if (count > 1)
-                        defaults.insert(first_by_type.at(return_type));
+                        defaults.insert(best_by_type.at(return_type));
                 }
             }
 

--- a/mxslc++/source/utils/load_mtlx.cpp
+++ b/mxslc++/source/utils/load_mtlx.cpp
@@ -24,22 +24,66 @@ namespace mxslc
 
     namespace
     {
+        string get_return_type_key(const mx::NodeDefPtr& nd)
+        {
+            const vector<mx::OutputPtr> outputs = nd->getActiveOutputs();
+
+            if (outputs.empty())
+                return nd->getType();
+
+            if (outputs.size() == 1)
+                return outputs.front()->getType();
+
+            string key;
+            for (const mx::OutputPtr& output : outputs)
+            {
+                if (not key.empty())
+                    key += "|";
+                key += output->getType();
+            }
+
+            return key;
+        }
+
         // Scan every nodedef in the loaded MaterialX document and pick the
-        // first definition read for each node category as the "default". This
-        // set is used to resolve the case where an MXSL signature can match
-        // more than one MTLX definition. Versioned nodedefs are reduced to
-        // their default version, matching how they are loaded.
+        // first definition read for each node category and return type pair as
+        // the "default", but only when there are multiple definitions for that
+        // pair. This keeps defaults focused on ambiguous overload groups.
+        // Versioned nodedefs are reduced to their default version, matching how
+        // they are loaded.
         unordered_set<string> get_default_node_defs(const mx::DocumentPtr& doc)
         {
-            unordered_set<string> seen_categories;
+            unordered_map<string, unordered_map<string, string>> first_by_category_and_type;
+            unordered_map<string, unordered_map<string, size_t>> counts_by_category_and_type;
             unordered_set<string> defaults;
+
             for (const mx::NodeDefPtr& nd : doc->getNodeDefs())
             {
                 if (nd->hasVersionString() and not nd->getDefaultVersion())
                     continue;
-                if (seen_categories.insert(nd->getNodeString()).second)
-                    defaults.insert(nd->getName());
+
+                const string& category = nd->getNodeString();
+                const string return_type = get_return_type_key(nd);
+
+                auto& first_by_type = first_by_category_and_type[category];
+                auto& counts_by_type = counts_by_category_and_type[category];
+
+                if (not contains(first_by_type, return_type))
+                    first_by_type.emplace(return_type, nd->getName());
+
+                ++counts_by_type[return_type];
             }
+
+            for (const auto& [category, counts_by_type] : counts_by_category_and_type)
+            {
+                const auto& first_by_type = first_by_category_and_type.at(category);
+                for (const auto& [return_type, count] : counts_by_type)
+                {
+                    if (count > 1)
+                        defaults.insert(first_by_type.at(return_type));
+                }
+            }
+
             return defaults;
         }
 

--- a/mxslc++/source/utils/load_mtlx.cpp
+++ b/mxslc++/source/utils/load_mtlx.cpp
@@ -24,26 +24,24 @@ namespace mxslc
 
     namespace
     {
-        const unordered_set<string> DEFAULT_NODE_DEFS = {
-            "ND_randomfloat_float",
-            "ND_randomcolor_float",
-
-            "ND_invert_float",
-            "ND_invert_vector2",
-            "ND_invert_vector3",
-            "ND_invert_vector4",
-            "ND_invert_color3",
-            "ND_invert_color4",
-
-            "ND_switch_float",
-            "ND_switch_vector2",
-            "ND_switch_vector3",
-            "ND_switch_vector4",
-            "ND_switch_color3",
-            "ND_switch_color4",
-            "ND_switch_matrix33",
-            "ND_switch_matrix44",
-        };
+        // Scan every nodedef in the loaded MaterialX document and pick the
+        // first definition read for each node category as the "default". This
+        // set is used to resolve the case where an MXSL signature can match
+        // more than one MTLX definition. Versioned nodedefs are reduced to
+        // their default version, matching how they are loaded.
+        unordered_set<string> get_default_node_defs(const mx::DocumentPtr& doc)
+        {
+            unordered_set<string> seen_categories;
+            unordered_set<string> defaults;
+            for (const mx::NodeDefPtr& nd : doc->getNodeDefs())
+            {
+                if (nd->hasVersionString() and not nd->getDefaultVersion())
+                    continue;
+                if (seen_categories.insert(nd->getNodeString()).second)
+                    defaults.insert(nd->getName());
+            }
+            return defaults;
+        }
 
         Parameter to_parameter(const mx::InputPtr& i, const size_t index)
         {
@@ -83,12 +81,12 @@ namespace mxslc
             return names;
         }
 
-        FuncPtr to_function(const mx::NodeDefPtr& nd)
+        FuncPtr to_function(const mx::NodeDefPtr& nd, const unordered_set<string>& default_node_defs)
         {
             const Scope& scope = Runtime::get().scope();
 
             ModifierList mods;
-            if (contains(DEFAULT_NODE_DEFS, nd->getName()))
+            if (contains(default_node_defs, nd->getName()))
                 mods.add(TokenType::Default);
 
             TypePtr type = get_type(nd);
@@ -112,11 +110,13 @@ namespace mxslc
             scope.add_primitive_type(td->getName());
         }
 
+        const unordered_set<string> default_node_defs = get_default_node_defs(doc);
+
         for (const mx::NodeDefPtr& nd : doc->getNodeDefs())
         {
             if (nd->hasVersionString() and not nd->getDefaultVersion())
                 continue;
-            scope.add_function(to_function(nd));
+            scope.add_function(to_function(nd, default_node_defs));
         }
     }
 


### PR DESCRIPTION
## Changes

- Makes default signature list be dynamic based on loaded library definitions
- Ensure there is a value set when creating input which is not explicitly specified.

### Implementation
- Make initialization of default signature list be based on nodedefs in MTLX vs hard-coded. Skip non-default versioned definitions.
- When compiling if there is no explicit value for an input, check for default value on nodedef otherwise you have inputs without values.

### Test
- Add in new Python unit test.

### Example

Default `normalmap` signature instantiated.
`scale` which is a differentiator is not explicitly specified and thus has no value unless this is set by checking the node definition.

```c
vec3 node_normalmap = normalmap();
float x = node_normalmap.scale;

color3 d = randomcolor();
float din = d.in;
```

Result sows float `scale` (vs vector `scale`) is default for `normalmap` and `randomcolor` has defaulted to `float` version of `in` (vs `int` version)
```xml
<?xml version="1.0"?>
<materialx version="1.39">
  <normalmap name="node_normalmap" type="vector3">
    <input name="scale" type="float" value="1.0" />
  </normalmap>
  <randomcolor name="d" type="color3">
    <input name="in" type="float" value="0.0" />
  </randomcolor>
</materialx>
```

These are explicit so do not use default signature resolution
```c
vec3 node_normalmap2 = normalmap(scale=1.0);
float x2 = node_normalmap2.scale;
vec3 node_normalmap3 = normalmap(scale=vec2{1.0,1.0});
vec2 x3 = node_normalmap3.scale;
```
